### PR TITLE
Rc<str> idents

### DIFF
--- a/core/src/bytecode/mod.rs
+++ b/core/src/bytecode/mod.rs
@@ -141,9 +141,9 @@ pub enum InstructionKind {
     ///
     /// stack = `[b, c, d, ...]`
     /// ident = a
-    Store { ident: String, declaration: bool },
+    Store { ident: Rc<str>, declaration: bool },
     /// Load the value of variable on to the stack.
-    Load { ident: String },
+    Load { ident: Rc<str> },
     /// Take 2 values from the stack, and index the first from the second, and push that onto the
     /// stack
     ///
@@ -290,12 +290,16 @@ impl DeserializeCtx<DeserializationContext> for InstructionKind {
                 InstructionKind::Push { value }
             }
             19 => {
-                let ident = String::deserialize(data)?;
+                // FIXME: This should probably reuse instances of Rc<str> if possible instead of
+                // creating a new one even if strings are the same.
+                let ident = String::deserialize(data)?.into();
                 let declaration = bool::deserialize(data)?;
                 InstructionKind::Store { ident, declaration }
             }
             20 => {
-                let ident = String::deserialize(data)?;
+                // FIXME: This should probably reuse instances of Rc<str> if possible instead of
+                // creating a new one even if strings are the same.
+                let ident = String::deserialize(data)?.into();
                 InstructionKind::Load { ident }
             }
             21 => InstructionKind::GetIndex,

--- a/core/src/bytecode/tests.rs
+++ b/core/src/bytecode/tests.rs
@@ -118,7 +118,7 @@ fn serialize_instr_store() {
     let test_store = |declaration| {
         test_serialize(
             InstructionKind::Store {
-                ident: "ident".to_owned(),
+                ident: "ident".into(),
                 declaration,
             },
             vec![
@@ -142,7 +142,7 @@ fn serialize_instr_store() {
 fn serialize_instr_load() {
     test_serialize(
         InstructionKind::Load {
-            ident: "some_ident".to_owned(),
+            ident: "some_ident".into(),
         },
         vec![
             20, b's', b'o', b'm', b'e', b'_', b'i', b'd', b'e', b'n', b't', b'\0',

--- a/core/src/evaluator/mod.rs
+++ b/core/src/evaluator/mod.rs
@@ -34,7 +34,7 @@ mod tests;
 /// use anilang::{SourceText, Scope, Diagnostics, Lexer, Parser, Lowerer, Evaluator, Value};
 ///
 /// let scope = Rc::new(Scope::new(0, None));
-/// scope.declare("var".to_owned(), Value::Int(1));
+/// scope.declare("var".into(), Value::Int(1));
 ///
 /// let src = SourceText::new("var + 2 + 3");
 /// let diagnostics = Diagnostics::new(&src);
@@ -126,7 +126,7 @@ impl<'diagnostics, 'src, 'bytecode> Evaluator<'diagnostics, 'src, 'bytecode> {
                 InstructionKind::Pop => self.evaluate_pop(),
                 InstructionKind::Push { value } => self.evaluate_push(value.clone()),
                 InstructionKind::Store { ident, declaration } => {
-                    self.evaluate_store(ident.clone(), *declaration)
+                    self.evaluate_store(Rc::clone(&ident), *declaration)
                 }
                 InstructionKind::Load { ident } => self.evaluate_load(ident),
                 InstructionKind::GetIndex => self.evaluate_get_index(),
@@ -290,7 +290,7 @@ impl<'diagnostics, 'src, 'bytecode> Evaluator<'diagnostics, 'src, 'bytecode> {
         self.stack.push(value);
     }
 
-    fn evaluate_store(&mut self, ident: String, declaration: bool) {
+    fn evaluate_store(&mut self, ident: Rc<str>, declaration: bool) {
         let v = self
             .stack
             .last()

--- a/core/src/lowerer/optimize_tests.rs
+++ b/core/src/lowerer/optimize_tests.rs
@@ -31,7 +31,7 @@ fn lower(node: SyntaxNode) -> Bytecode {
 fn optimize_arithmetic_expr() {
     let bytecode = lower(SyntaxNode::BlockNode(node::BlockNode {
         block: vec![SyntaxNode::DeclarationNode(node::DeclarationNode {
-            ident: "a".to_owned(),
+            ident: "a".into(),
             value: Box::new(SyntaxNode::BinaryNode(node::BinaryNode {
                 operator: TokenKind::StarOperator,
                 left: Box::new(SyntaxNode::LiteralNode(node::LiteralNode {
@@ -58,7 +58,7 @@ fn optimize_arithmetic_expr() {
             .into(),
             InstructionKind::Push { value: i(12) }.into(),
             InstructionKind::Store {
-                ident: "a".to_owned(),
+                ident: "a".into(),
                 declaration: true
             }
             .into(),
@@ -71,7 +71,7 @@ fn optimize_arithmetic_expr() {
 fn optimize_index() {
     let bytecode = lower(SyntaxNode::BlockNode(node::BlockNode {
         block: vec![SyntaxNode::DeclarationNode(node::DeclarationNode {
-            ident: "a".to_owned(),
+            ident: "a".into(),
             value: Box::new(SyntaxNode::BinaryNode(node::BinaryNode {
                 operator: TokenKind::StarOperator,
                 left: Box::new(SyntaxNode::IndexNode(node::IndexNode {
@@ -118,7 +118,7 @@ fn optimize_index() {
             .into(),
             InstructionKind::Push { value: i(12) }.into(),
             InstructionKind::Store {
-                ident: "a".to_owned(),
+                ident: "a".into(),
                 declaration: true
             }
             .into(),
@@ -191,12 +191,12 @@ fn optimize_const_if_condition() {
                 })),
                 if_block: node::BlockNode {
                     block: vec![SyntaxNode::AssignmentNode(node::AssignmentNode {
-                        ident: "a".to_owned(),
+                        ident: "a".into(),
                         indices: None,
                         value: Box::new(SyntaxNode::BinaryNode(node::BinaryNode {
                             operator: TokenKind::PlusOperator,
                             left: Box::new(SyntaxNode::VariableNode(node::VariableNode {
-                                ident: "a".to_owned(),
+                                ident: "a".into(),
                                 span: span(),
                             })),
                             right: Box::new(SyntaxNode::LiteralNode(node::LiteralNode {
@@ -211,12 +211,12 @@ fn optimize_const_if_condition() {
                 },
                 else_block: Some(node::BlockNode {
                     block: vec![SyntaxNode::AssignmentNode(node::AssignmentNode {
-                        ident: "b".to_owned(),
+                        ident: "b".into(),
                         indices: None,
                         value: Box::new(SyntaxNode::BinaryNode(node::BinaryNode {
                             operator: TokenKind::StarOperator,
                             left: Box::new(SyntaxNode::VariableNode(node::VariableNode {
-                                ident: "b".to_owned(),
+                                ident: "b".into(),
                                 span: span(),
                             })),
                             right: Box::new(SyntaxNode::LiteralNode(node::LiteralNode {
@@ -247,13 +247,10 @@ fn optimize_const_if_condition() {
             }
             .into(),
             InstructionKind::Push { value: i(2) }.into(),
-            InstructionKind::Load {
-                ident: "a".to_owned()
-            }
-            .into(),
+            InstructionKind::Load { ident: "a".into() }.into(),
             InstructionKind::BinaryAdd.into(),
             InstructionKind::Store {
-                ident: "a".to_owned(),
+                ident: "a".into(),
                 declaration: false
             }
             .into(),
@@ -274,13 +271,10 @@ fn optimize_const_if_condition() {
             }
             .into(),
             InstructionKind::Push { value: i(4) }.into(),
-            InstructionKind::Load {
-                ident: "b".to_owned()
-            }
-            .into(),
+            InstructionKind::Load { ident: "b".into() }.into(),
             InstructionKind::BinaryMultiply.into(),
             InstructionKind::Store {
-                ident: "b".to_owned(),
+                ident: "b".into(),
                 declaration: false
             }
             .into(),

--- a/core/src/parser/mod.rs
+++ b/core/src/parser/mod.rs
@@ -232,7 +232,7 @@ impl<'diagnostics, 'src> Parser<'diagnostics, 'src> {
 
     fn parse_block(&self, delim: TokenKind) -> node::BlockNode {
         let s = self.cur().text_span.start();
-        let mut block: Vec<SyntaxNode> = Vec::new();
+        let mut block = Vec::new();
 
         while self.cur().kind != delim {
             block.push(self.parse_statement());
@@ -434,7 +434,7 @@ impl<'diagnostics, 'src> Parser<'diagnostics, 'src> {
         let interface_ident = self.new_ident(&interface_ident_span);
         self.match_token(TokenKind::OpenBrace);
 
-        let mut values: Vec<(String, _)> = Vec::new();
+        let mut values = Vec::new();
 
         let mut found_constructor = false;
 

--- a/core/src/parser/tests.rs
+++ b/core/src/parser/tests.rs
@@ -33,7 +33,7 @@ fn match_assignment(
             indices,
             ..
         }) => {
-            assert_eq!(ident.as_str(), expected_ident);
+            assert_eq!(&*ident, expected_ident);
             if let Some(ref indices) = indices {
                 assert_eq!(indices.len(), indices_len);
             }
@@ -78,7 +78,7 @@ fn match_break(node: SyntaxNode) {
 fn match_declaration(node: SyntaxNode, expected_ident: &str) -> SyntaxNode {
     match node {
         SyntaxNode::DeclarationNode(node::DeclarationNode { ident, value, .. }) => {
-            assert_eq!(ident.as_str(), expected_ident);
+            assert_eq!(&*ident, expected_ident);
             *value
         }
         n => panic!("expected declaration, got {:?}", n),
@@ -107,10 +107,8 @@ fn match_fn_declaration(
         SyntaxNode::FnDeclarationNode(node::FnDeclarationNode {
             ident, args, block, ..
         }) => {
-            assert_eq!(ident.as_ref().map(String::as_str), expected_ident);
-            args.iter()
-                .map(String::as_str)
-                .eq(expected_args.into_iter());
+            assert_eq!(ident.as_ref().map(Rc::as_ref), expected_ident);
+            args.iter().map(Rc::as_ref).eq(expected_args.into_iter());
             assert_eq!(block.block.len(), block_len);
             block.block
         }
@@ -158,7 +156,7 @@ fn match_interface(
 ) -> Vec<(String, SyntaxNode)> {
     match node {
         SyntaxNode::InterfaceNode(node::InterfaceNode { ident, values, .. }) => {
-            assert_eq!(ident.as_str(), expected_ident);
+            assert_eq!(dbg!(&*ident), expected_ident);
             assert_eq!(values.len(), len);
             values
         }
@@ -230,7 +228,7 @@ fn match_unary(node: SyntaxNode, expected_operator: TokenKind) -> SyntaxNode {
 fn match_variable(node: SyntaxNode, expected_ident: &str) {
     match node {
         SyntaxNode::VariableNode(node::VariableNode { ident, .. }) => {
-            assert_eq!(ident.as_str(), expected_ident)
+            assert_eq!(&*ident, expected_ident)
         }
         n => panic!("expected variable, got {:?}", n),
     }

--- a/core/src/serialize.rs
+++ b/core/src/serialize.rs
@@ -78,13 +78,18 @@ impl Serialize for str {
 
 impl Serialize for Rc<str> {
     fn serialize<W: Write>(&self, buf: &mut W) -> Result<usize> {
-        str::serialize(&**self, buf)
+        let ptr = Self::as_ptr(self) as *const u8 as usize;
+        ptr.serialize(buf)
     }
 }
 
-impl Deserialize for Rc<str> {
-    fn deserialize<R: BufRead>(data: &mut R) -> Result<Rc<str>> {
-        String::deserialize(data).map(Into::into)
+impl DeserializeCtx<DeserializationContext> for Rc<str> {
+    fn deserialize_with_context<R: BufRead>(
+        data: &mut R,
+        ctx: &mut DeserializationContext,
+    ) -> Result<Rc<str>> {
+        let id = usize::deserialize(data)?;
+        Ok(ctx.get_ident(id))
     }
 }
 

--- a/core/src/serialize.rs
+++ b/core/src/serialize.rs
@@ -186,12 +186,14 @@ use std::rc::Rc;
 pub struct DeserializationContext {
     global: Option<Rc<Scope>>,
     scopes: Vec<Rc<Scope>>,
+    idents: HashMap<usize, Rc<str>>,
 }
 
 impl DeserializationContext {
-    pub fn new(len: usize, global: Option<Rc<Scope>>) -> Self {
+    pub fn new(num_scopes: usize, num_idents: usize, global: Option<Rc<Scope>>) -> Self {
         Self {
-            scopes: Vec::with_capacity(len),
+            scopes: Vec::with_capacity(num_scopes),
+            idents: HashMap::with_capacity(num_idents),
             global,
         }
     }
@@ -210,7 +212,15 @@ impl DeserializationContext {
         )))
     }
 
-    pub fn get_scope(&mut self, id: usize) -> Rc<Scope> {
+    pub fn get_scope(&self, id: usize) -> Rc<Scope> {
         Rc::clone(&self.scopes[id])
+    }
+
+    pub fn add_ident(&mut self, id: usize, ident: Rc<str>) {
+        self.idents.insert(id, ident);
+    }
+
+    pub fn get_ident(&self, id: usize) -> Rc<str> {
+        Rc::clone(&self.idents[&id])
     }
 }

--- a/core/src/serialize.rs
+++ b/core/src/serialize.rs
@@ -1,9 +1,6 @@
 use std::io::{BufRead, Result, Write};
 
-pub trait Serialize
-where
-    Self: Sized,
-{
+pub trait Serialize {
     fn serialize<W: Write>(&self, writer: &mut W) -> Result<usize>;
 }
 
@@ -71,11 +68,29 @@ impl Deserialize for usize {
     }
 }
 
-impl Serialize for String {
+impl Serialize for str {
     fn serialize<W: Write>(&self, buf: &mut W) -> Result<usize> {
         buf.write_all(self.as_bytes())?;
         buf.write_all(b"\0")?;
         Ok(self.len() + 1)
+    }
+}
+
+impl Serialize for Rc<str> {
+    fn serialize<W: Write>(&self, buf: &mut W) -> Result<usize> {
+        str::serialize(&**self, buf)
+    }
+}
+
+impl Deserialize for Rc<str> {
+    fn deserialize<R: BufRead>(data: &mut R) -> Result<Rc<str>> {
+        String::deserialize(data).map(Into::into)
+    }
+}
+
+impl Serialize for String {
+    fn serialize<W: Write>(&self, buf: &mut W) -> Result<usize> {
+        self.as_str().serialize(buf)
     }
 }
 

--- a/core/src/syntax_node/assignment_node.rs
+++ b/core/src/syntax_node/assignment_node.rs
@@ -1,13 +1,13 @@
 use super::{print_node, SyntaxNode};
-use crate::source_text::SourceText;
 use crate::text_span::TextSpan;
 use crate::tokens::Token;
 use crossterm::style;
+use std::rc::Rc;
 
 #[derive(Debug, Clone)]
 pub struct AssignmentNode {
     pub span: TextSpan,
-    pub ident: String,
+    pub ident: Rc<str>,
     /// For an assignment `<variable>[<index>] = <value>`, index refers to the <index>, and *not*
     /// a `IndexNode`
     pub indices: Option<Vec<SyntaxNode>>,
@@ -16,13 +16,13 @@ pub struct AssignmentNode {
 
 impl AssignmentNode {
     pub fn new(
+        ident: Rc<str>,
         ident_token: &Token,
         indices: Option<Vec<SyntaxNode>>,
         value: SyntaxNode,
-        src: &SourceText,
     ) -> Self {
         Self {
-            ident: src[&ident_token.text_span].to_owned(),
+            ident,
             span: TextSpan::from_spans(&ident_token.text_span, value.span()),
             indices,
             value: Box::new(value),

--- a/core/src/syntax_node/declaration_node.rs
+++ b/core/src/syntax_node/declaration_node.rs
@@ -1,31 +1,26 @@
 use super::{print_node, SyntaxNode};
-use crate::source_text::SourceText;
 use crate::text_span::TextSpan;
 use crate::tokens::Token;
 use crossterm::style;
+use std::rc::Rc;
 
 #[derive(Debug, Clone)]
 pub struct DeclarationNode {
     pub span: TextSpan,
-    pub ident: String,
+    pub ident: Rc<str>,
     pub value: Box<SyntaxNode>,
 }
 
 impl DeclarationNode {
-    pub fn new(
-        declaration_token: &Token,
-        ident_token: &Token,
-        value: SyntaxNode,
-        src: &SourceText,
-    ) -> Self {
+    pub fn new(declaration_token: &Token, ident: Rc<str>, value: SyntaxNode) -> Self {
         Self {
-            ident: src[&ident_token.text_span].to_owned(),
+            ident,
             span: TextSpan::from_spans(&declaration_token.text_span, value.span()),
             value: Box::new(value),
         }
     }
 
-    pub fn from_span(ident: String, value: Box<SyntaxNode>, span: TextSpan) -> Self {
+    pub fn from_span(ident: Rc<str>, value: Box<SyntaxNode>, span: TextSpan) -> Self {
         Self { ident, value, span }
     }
 

--- a/core/src/syntax_node/fn_declaration_node.rs
+++ b/core/src/syntax_node/fn_declaration_node.rs
@@ -2,20 +2,21 @@ use super::{print_node, BlockNode};
 use crate::text_span::TextSpan;
 use crate::tokens::Token;
 use crossterm::style;
+use std::rc::Rc;
 
 #[derive(Debug, Clone)]
 pub struct FnDeclarationNode {
     pub span: TextSpan,
-    pub ident: Option<String>,
-    pub args: Vec<String>,
+    pub ident: Option<Rc<str>>,
+    pub args: Vec<Rc<str>>,
     pub block: BlockNode,
 }
 
 impl FnDeclarationNode {
     pub fn new(
         fn_token: &Token,
-        ident: Option<String>,
-        args: Vec<String>,
+        ident: Option<Rc<str>>,
+        args: Vec<Rc<str>>,
         block: BlockNode,
     ) -> Self {
         Self {
@@ -27,8 +28,8 @@ impl FnDeclarationNode {
     }
 
     pub fn with_span(
-        ident: Option<String>,
-        args: Vec<String>,
+        ident: Option<Rc<str>>,
+        args: Vec<Rc<str>>,
         block: BlockNode,
         span: TextSpan,
     ) -> Self {

--- a/core/src/syntax_node/interface_node.rs
+++ b/core/src/syntax_node/interface_node.rs
@@ -3,10 +3,11 @@ use crate::text_span::TextSpan;
 use crate::tokens::Token;
 use crossterm::{queue, style};
 use std::io::Write;
+use std::rc::Rc;
 
-#[derive(Default, Debug, Clone)]
+#[derive(Debug, Clone)]
 pub struct InterfaceNode {
-    pub ident: String,
+    pub ident: Rc<str>,
     pub span: TextSpan,
     /// The default values present in the object produced from interface.
     ///
@@ -29,7 +30,7 @@ pub struct InterfaceNode {
 impl InterfaceNode {
     pub fn new(
         interface_token: &Token,
-        ident: String,
+        ident: Rc<str>,
         values: Vec<(String, SyntaxNode)>,
         close_brace: &Token,
     ) -> Self {

--- a/core/src/syntax_node/variable_node.rs
+++ b/core/src/syntax_node/variable_node.rs
@@ -1,22 +1,15 @@
-use crate::source_text::SourceText;
 use crate::text_span::TextSpan;
 use crossterm::style;
+use std::rc::Rc;
 
 #[derive(Debug, Clone)]
 pub struct VariableNode {
     pub span: TextSpan,
-    pub ident: String,
+    pub ident: Rc<str>,
 }
 
 impl VariableNode {
-    pub fn new(span: TextSpan, src: &SourceText) -> Self {
-        Self {
-            ident: src[&span].to_owned(),
-            span,
-        }
-    }
-
-    pub fn raw(ident: String, span: TextSpan) -> Self {
+    pub fn new(ident: Rc<str>, span: TextSpan) -> Self {
         Self { ident, span }
     }
 

--- a/core/src/value/from_impl.rs
+++ b/core/src/value/from_impl.rs
@@ -261,10 +261,7 @@ mod tests {
 
     #[test]
     fn val_to_ref_fn() {
-        let rc_f = Rc::new(Function::anilang_fn(
-            vec!["a".to_owned(), "b".to_owned()],
-            vec![],
-        ));
+        let rc_f = Rc::new(Function::anilang_fn(vec!["a".into(), "b".into()], vec![]));
         let f = Value::Function(Rc::clone(&rc_f));
         assert!(Rc::ptr_eq(&rc_f, &f.into_rc_fn()));
     }

--- a/core/src/value/function/anilang_fn.rs
+++ b/core/src/value/function/anilang_fn.rs
@@ -6,12 +6,12 @@ use std::rc::Rc;
 
 #[derive(Debug, Clone)]
 pub struct AnilangFn {
-    pub args: Vec<String>,
+    pub args: Vec<Rc<str>>,
     pub body: Bytecode,
 }
 
 impl AnilangFn {
-    pub fn new(args: Vec<String>, body: Bytecode) -> Self {
+    pub fn new(args: Vec<Rc<str>>, body: Bytecode) -> Self {
         Self { args, body }
     }
 

--- a/core/src/value/function/mod.rs
+++ b/core/src/value/function/mod.rs
@@ -20,7 +20,7 @@ impl Function {
         }
     }
 
-    pub fn anilang_fn(args: Vec<String>, body: Bytecode) -> Self {
+    pub fn anilang_fn(args: Vec<Rc<str>>, body: Bytecode) -> Self {
         Self {
             fn_type: FunctionType::AnilangFn(AnilangFn::new(args, body)),
             this: None,

--- a/core/src/value/serialize.rs
+++ b/core/src/value/serialize.rs
@@ -172,15 +172,15 @@ mod tests {
     #[rustfmt::skip]
     fn function_serialize() {
         let f = Value::Function(Rc::new(Function::anilang_fn(
-            vec!["a".to_owned(), "b".to_owned()],
+            vec!["a".into(), "b".into()],
             vec![
                 InstructionKind::PushVar { scope: Rc::new(crate::Scope::new(0, None)) }.into(),
                 InstructionKind::Load {
-                    ident: "b".to_owned(),
+                    ident: "b".into(),
                 }
                 .into(),
                 InstructionKind::Load {
-                    ident: "a".to_owned(),
+                    ident: "a".into(),
                 }
                 .into(),
                 InstructionKind::BinaryAdd.into(),

--- a/core/tests/common/mod.rs
+++ b/core/tests/common/mod.rs
@@ -7,7 +7,7 @@ fn base_scope() -> Rc<anilang::Scope> {
     let scope = Rc::new(anilang::Scope::new(0, None));
     scope
         .declare(
-            "assert".to_owned(),
+            "assert".into(),
             anilang::Value::Function(Rc::new(Function::native_fn(native::assert))),
         )
         .expect("Could not declare assert");

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -1,7 +1,9 @@
 use anilang::Serialize;
 use crossterm::Result;
+use std::collections::HashSet;
 use std::fs;
 use std::path::PathBuf;
+use std::rc::Rc;
 
 pub fn compile(
     input_file: PathBuf,
@@ -31,10 +33,15 @@ pub fn compile(
         let mut output_file = fs::File::create(output_file)?;
         src.serialize(&mut output_file)?;
 
-        // Serialize scopes
-        count_scopes(&bytecode[..]).serialize(&mut output_file)?;
+        let mut idents = HashSet::new();
 
-        serialize_scopes(&bytecode[..], &mut output_file)?;
+        // Serialize scopes
+        count_scopes(&bytecode[..], &mut idents).serialize(&mut output_file)?;
+        idents.len().serialize(&mut output_file)?;
+
+        idents.clear();
+
+        serialize_scopes(&bytecode[..], &mut output_file, &mut idents)?;
 
         // Serialize the Instructions
         bytecode.serialize(&mut output_file)?;
@@ -53,7 +60,7 @@ pub fn compile(
 
 use anilang::{Instruction, InstructionKind, Value};
 
-fn count_scopes(bytecode: &[Instruction]) -> usize {
+fn count_scopes(bytecode: &[Instruction], idents: &mut HashSet<usize>) -> usize {
     let mut num_scopes = 0;
 
     for instr in bytecode {
@@ -62,8 +69,14 @@ fn count_scopes(bytecode: &[Instruction]) -> usize {
             InstructionKind::Push { value } => {
                 if let Value::Function(func) = value {
                     if let Some(func) = func.as_anilang_fn() {
-                        num_scopes += count_scopes(&func.body[..])
+                        num_scopes += count_scopes(&func.body[..], idents)
                     }
+                }
+            }
+            InstructionKind::Load { ident, .. } | InstructionKind::Store { ident, .. } => {
+                let ident = to_usize(ident);
+                if !idents.contains(&ident) {
+                    idents.insert(ident);
                 }
             }
             _ => {}
@@ -73,10 +86,15 @@ fn count_scopes(bytecode: &[Instruction]) -> usize {
     num_scopes
 }
 
-fn serialize_scopes(bytecode: &[Instruction], output_file: &mut fs::File) -> Result<()> {
+fn serialize_scopes(
+    bytecode: &[Instruction],
+    output_file: &mut fs::File,
+    idents: &mut HashSet<usize>,
+) -> Result<()> {
     for instr in bytecode {
         match &instr.kind {
             InstructionKind::PushVar { scope } => {
+                false.serialize(output_file)?;
                 if let Some(parent_id) = scope.parent_id() {
                     parent_id.serialize(output_file)?;
                 } else {
@@ -86,8 +104,17 @@ fn serialize_scopes(bytecode: &[Instruction], output_file: &mut fs::File) -> Res
             InstructionKind::Push { value } => {
                 if let Value::Function(func) = value {
                     if let Some(func) = func.as_anilang_fn() {
-                        serialize_scopes(&func.body[..], output_file)?;
+                        serialize_scopes(&func.body[..], output_file, idents)?;
                     }
+                }
+            }
+            InstructionKind::Store { ident, .. } | InstructionKind::Load { ident } => {
+                let ident_usize = to_usize(ident);
+                if !idents.contains(&ident_usize) {
+                    true.serialize(output_file)?;
+                    ident_usize.serialize(output_file)?;
+                    ident.serialize(output_file)?;
+                    idents.insert(ident_usize);
                 }
             }
             _ => {}
@@ -95,4 +122,8 @@ fn serialize_scopes(bytecode: &[Instruction], output_file: &mut fs::File) -> Res
     }
 
     Ok(())
+}
+
+fn to_usize(rc: &Rc<str>) -> usize {
+    Rc::as_ptr(rc) as *const u8 as usize
 }

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -113,7 +113,7 @@ fn serialize_scopes(
                 if !idents.contains(&ident_usize) {
                     true.serialize(output_file)?;
                     ident_usize.serialize(output_file)?;
-                    ident.serialize(output_file)?;
+                    ident[..].serialize(output_file)?;
                     idents.insert(ident_usize);
                 }
             }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -21,7 +21,7 @@ pub fn run(bin_file: PathBuf, show_bytecode: bool) -> io::Result<()> {
         let is_ident = bool::deserialize(&mut bin)?;
         if is_ident {
             let id = usize::deserialize(&mut bin)?;
-            let ident = Deserialize::deserialize(&mut bin)?;
+            let ident = String::deserialize(&mut bin)?.into();
             ctx.add_ident(id, ident);
         } else {
             let parent_id = usize::deserialize(&mut bin)?;

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -12,17 +12,29 @@ pub fn run(bin_file: PathBuf, show_bytecode: bool) -> io::Result<()> {
     let std = crate::stdlib::make_std();
 
     let num_scopes = usize::deserialize(&mut bin)?;
-    let mut ctx = anilang::DeserializationContext::new(num_scopes, Some(std));
-    for i in 0..num_scopes {
-        let parent_id = usize::deserialize(&mut bin)?;
+    let num_idents = usize::deserialize(&mut bin)?;
 
-        let parent_id = if parent_id != usize::MAX {
-            Some(parent_id)
+    let mut ctx = anilang::DeserializationContext::new(num_scopes, num_idents, Some(std));
+    let mut i = 0;
+
+    for _ in 0..(num_scopes + num_idents) {
+        let is_ident = bool::deserialize(&mut bin)?;
+        if is_ident {
+            let id = usize::deserialize(&mut bin)?;
+            let ident = Deserialize::deserialize(&mut bin)?;
+            ctx.add_ident(id, ident);
         } else {
-            None
-        };
+            let parent_id = usize::deserialize(&mut bin)?;
 
-        ctx.add_scope(i, parent_id);
+            let parent_id = if parent_id != usize::MAX {
+                Some(parent_id)
+            } else {
+                None
+            };
+
+            ctx.add_scope(i, parent_id);
+            i += 1;
+        }
     }
 
     let bytecode = Vec::deserialize_with_context(&mut bin, &mut ctx)?;

--- a/src/stdlib.rs
+++ b/src/stdlib.rs
@@ -6,7 +6,7 @@ macro_rules! declare_native_fn {
     ($scope:expr => $fn_name:ident) => {
         $scope
             .declare(
-                stringify!($fn_name).to_owned(),
+                stringify!($fn_name).into(),
                 Value::Function(Rc::new(Function::native_fn(native::$fn_name))),
             )
             .unwrap_or_else(|_| {


### PR DESCRIPTION
Variable idents are often required to be cloned, so allocating a whole new buffer each time, even though idents will be immutable is inefficient. Now same idents all point to the same buffer instead of different ones.