### PR TITLE
Garbage Collection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -364,6 +364,7 @@ name = "evaluator"
 version = "0.1.0"
 dependencies = [
  "diagnostics",
+ "gc",
  "source",
  "vm",
 ]
@@ -446,6 +447,7 @@ name = "intermediaries"
 version = "0.1.0"
 dependencies = [
  "crossterm",
+ "gc",
  "source",
  "vm",
 ]
@@ -558,6 +560,7 @@ name = "lowerer"
 version = "0.1.0"
 dependencies = [
  "diagnostics",
+ "gc",
  "intermediaries",
  "source",
  "vm",
@@ -732,6 +735,7 @@ name = "parser"
 version = "0.1.0"
 dependencies = [
  "diagnostics",
+ "gc",
  "intermediaries",
  "source",
  "vm",
@@ -1203,6 +1207,7 @@ version = "0.1.0"
 dependencies = [
  "crossterm",
  "enumflags2",
+ "gc",
  "serialize",
  "source",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -375,6 +375,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "gc"
+version = "0.1.0"
+
+[[package]]
 name = "generator"
 version = "0.6.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ members = [
     "crates/anilang",
     "crates/diagnostics",
     "crates/evaluator",
+    "crates/gc",
     "crates/intermediaries",
     "crates/lexer",
     "crates/lowerer",

--- a/crates/anilang/src/compiler.rs
+++ b/crates/anilang/src/compiler.rs
@@ -66,11 +66,11 @@ fn count_scopes(bytecode: &[Instruction], idents: &mut HashSet<usize>) -> usize 
     for instr in bytecode {
         match &instr.kind {
             InstructionKind::PushVar { .. } => num_scopes += 1,
-            InstructionKind::Push { value } => {
-                if let Value::Function(func) = value {
-                    if let Some(func) = func.as_anilang_fn() {
-                        num_scopes += count_scopes(&func.body[..], idents)
-                    }
+            InstructionKind::Push {
+                value: Value::Function(func),
+            } => {
+                if let Some(func) = func.as_anilang_fn() {
+                    num_scopes += count_scopes(&func.body[..], idents)
                 }
             }
             InstructionKind::Load { ident, .. } | InstructionKind::Store { ident, .. } => {
@@ -101,11 +101,11 @@ fn serialize_scopes(
                     usize::MAX.serialize(output_file)?;
                 }
             }
-            InstructionKind::Push { value } => {
-                if let Value::Function(func) = value {
-                    if let Some(func) = func.as_anilang_fn() {
-                        serialize_scopes(&func.body[..], output_file, idents)?;
-                    }
+            InstructionKind::Push {
+                value: Value::Function(func),
+            } => {
+                if let Some(func) = func.as_anilang_fn() {
+                    serialize_scopes(&func.body[..], output_file, idents)?;
                 }
             }
             InstructionKind::Store { ident, .. } | InstructionKind::Load { ident } => {

--- a/crates/anilang/src/lib.rs
+++ b/crates/anilang/src/lib.rs
@@ -7,6 +7,6 @@ pub use parser::Parser;
 pub use serialize::{Deserialize, DeserializeCtx, Serialize};
 pub use source::SourceText;
 pub use vm::{
-    function, print_bytecode, Bytecode, DeserializationContext, Instruction, InstructionKind,
-    LabelNumber, Scope, Type, Value,
+    function, print_bytecode, print_value, Bytecode, DeserializationContext, FmtValue, Instruction,
+    InstructionKind, LabelNumber, Scope, Type, Value,
 };

--- a/crates/anilang/src/repl.rs
+++ b/crates/anilang/src/repl.rs
@@ -81,7 +81,7 @@ pub fn run(mut show_ast: bool, mut show_bytecode: bool) {
             let value = anilang::Evaluator::evaluate(&bytecode[..], &diagnostics);
             match value {
                 anilang::Value::Null => {}
-                value if !diagnostics.any() => println!("{:?}", value),
+                value if !diagnostics.any() => anilang::print_value(&value, true),
                 _ => {}
             }
         }

--- a/crates/evaluator/Cargo.toml
+++ b/crates/evaluator/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2018"
 [dependencies]
 vm = { path = "../vm" }
 diagnostics = { path = "../diagnostics" }
+gc = { path = "../gc" }
 
 [dev-dependencies]
 source = { path = "../source" }

--- a/crates/evaluator/src/lib.rs
+++ b/crates/evaluator/src/lib.rs
@@ -502,7 +502,7 @@ impl<'diagnostics, 'src, 'bytecode> Evaluator<'diagnostics, 'src, 'bytecode> {
                 return;
             }
 
-            map.insert(k.to_ref_str().to_owned(), v);
+            map.insert(k.into_string(), v);
         }
 
         self.stack.push(Value::Object(Gc::new(RefCell::new(map))));

--- a/crates/evaluator/src/lib.rs
+++ b/crates/evaluator/src/lib.rs
@@ -1,4 +1,5 @@
 use diagnostics::Diagnostics;
+use gc::Gc;
 use std::cell::RefCell;
 use std::collections::HashMap;
 use std::rc::Rc;
@@ -476,7 +477,7 @@ impl<'diagnostics, 'src, 'bytecode> Evaluator<'diagnostics, 'src, 'bytecode> {
             list.push(self.stack.pop().unwrap_or_else(e_msg));
         }
 
-        self.stack.push(Value::List(Rc::new(RefCell::new(list))));
+        self.stack.push(Value::List(Gc::new(RefCell::new(list))));
     }
 
     fn evaluate_make_object(&mut self, len: usize) {
@@ -501,10 +502,10 @@ impl<'diagnostics, 'src, 'bytecode> Evaluator<'diagnostics, 'src, 'bytecode> {
                 return;
             }
 
-            map.insert(k.into_str(), v);
+            map.insert(k.to_ref_str().to_owned(), v);
         }
 
-        self.stack.push(Value::Object(Rc::new(RefCell::new(map))));
+        self.stack.push(Value::Object(Gc::new(RefCell::new(map))));
     }
 
     fn evaluate_make_range(&mut self) {

--- a/crates/gc/Cargo.toml
+++ b/crates/gc/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "gc"
+version = "0.1.0"
+authors = ["Lutetium Vanadium <luv.s7000@gmail.com>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/crates/gc/src/flag_usize.rs
+++ b/crates/gc/src/flag_usize.rs
@@ -1,0 +1,151 @@
+use std::cell::Cell;
+use std::fmt;
+use std::mem;
+
+const USIZE_BIT_WIDTH: usize = mem::size_of::<usize>() * 8;
+
+const FLAG_BIT_OFFSET: usize = USIZE_BIT_WIDTH - 1;
+const FLAG_MASK: usize = 1 << FLAG_BIT_OFFSET;
+
+const USIZE_MASK: usize = !FLAG_MASK;
+
+/// A usize and a bool within the size of usize.
+///
+/// The usize must not exceed `usize::MAX / 2`. Exceeding it will cause a panic.
+pub(crate) struct FlagUsize {
+    flags: Cell<usize>,
+}
+
+impl FlagUsize {
+    /// Creates a `FlagUsize`.
+    ///
+    /// # Panics
+    /// if n exceeds `usize::MAX / 2`, it will panic.
+    pub fn new(n: usize, flag: bool) -> Self {
+        assert!(
+            n <= USIZE_MASK,
+            "FlagUsize: {} greater than max {}",
+            n,
+            USIZE_MASK
+        );
+
+        FlagUsize {
+            flags: Cell::new(n | (flag as usize) << FLAG_BIT_OFFSET),
+        }
+    }
+
+    /// Gets the flag.
+    pub fn get_flag(&self) -> bool {
+        (self.flags.get() & FLAG_MASK) != 0
+    }
+
+    /// Sets the flag.
+    pub fn set_flag(&self, flag: bool) {
+        self.flags
+            .set(self.get_usize() | (flag as usize) << FLAG_BIT_OFFSET);
+    }
+
+    /// Gets the usize.
+    pub fn get_usize(&self) -> usize {
+        self.flags.get() & USIZE_MASK
+    }
+
+    /// Sets the usize.
+    ///
+    /// # Panics
+    /// if n exceeds `usize::MAX / 2`, it will panic.
+    pub fn set_usize(&self, n: usize) {
+        assert!(
+            n <= USIZE_MASK,
+            "FlagUsize: {} greater than max {}",
+            n,
+            USIZE_MASK
+        );
+
+        self.flags.set(n | (self.flags.get() & FLAG_MASK));
+    }
+}
+
+impl fmt::Debug for FlagUsize {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("FlagUsize")
+            .field("n", &self.get_usize())
+            .field("flag", &self.get_flag())
+            .finish()
+    }
+}
+
+impl fmt::Binary for FlagUsize {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if f.alternate() {
+            write!(f, "{:#0w$b}", self.flags.get(), w = USIZE_BIT_WIDTH)
+        } else {
+            write!(
+                f,
+                "{} {:0w$b}",
+                self.get_flag() as u8,
+                self.get_usize(),
+                w = FLAG_BIT_OFFSET
+            )
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_state(flags: &FlagUsize, n: usize, flag: bool) {
+        let mut state = n;
+        if flag {
+            state |= FLAG_MASK;
+        }
+
+        assert_eq!(flags.get_usize(), n);
+        assert_eq!(flags.get_flag(), flag);
+        assert_eq!(flags.flags.get(), state);
+    }
+
+    #[test]
+    fn test_flag_usize() {
+        let flags = &FlagUsize::new(1, false);
+
+        test_state(flags, 1, false);
+
+        flags.set_flag(true);
+        test_state(flags, 1, true);
+
+        flags.set_usize(2);
+        test_state(flags, 2, true);
+
+        flags.set_flag(false);
+        test_state(flags, 2, false);
+
+        flags.set_usize(0);
+        test_state(flags, 0, false);
+    }
+
+    fn set_above_max() {
+        let flags = &FlagUsize::new(10, true);
+
+        test_state(flags, 10, true);
+
+        flags.set_usize((usize::MAX >> 1) + 1);
+    }
+
+    #[cfg(target_pointer_width = "64")]
+    #[test]
+    #[should_panic(
+        expected = "FlagUsize: 9223372036854775808 greater than max 9223372036854775807"
+    )]
+    fn test_set_above_max() {
+        set_above_max();
+    }
+
+    #[cfg(target_pointer_width = "32")]
+    #[test]
+    #[should_panic(expected = "FlagUsize: 2147483648 greater than max 2147483647")]
+    fn test_set_above_max() {
+        set_above_max();
+    }
+}

--- a/crates/gc/src/guards.rs
+++ b/crates/gc/src/guards.rs
@@ -1,0 +1,87 @@
+use std::cell::Cell;
+use std::num::NonZeroUsize;
+use std::thread_local;
+
+thread_local! {
+    /// The id of the current inner being dropped. It is undefined behaviour to dereference a
+    /// pointer to the inner during this time (unless you are the sweeper), as an inner may or may
+    /// not be dropping at that time.
+    static DROPPING_ID: Cell<Option<NonZeroUsize>> = Cell::new(None);
+
+    /// A flag to indicate whether a garbage collection is going on. It is undefined behaviour to
+    /// create a new `GcInner` during this time.
+    static IN_GC: Cell<bool> = Cell::new(false);
+}
+
+/// A guard to take while dropping an inner.
+pub(crate) struct DropGuard {
+    _private: (),
+}
+
+impl DropGuard {
+    /// Tries to take the DropGuard. If None is returned, some inner is already dropping.
+    pub(crate) fn take(id: NonZeroUsize) -> Option<DropGuard> {
+        DROPPING_ID.with(|dropping_id| {
+            if dropping_id.get().is_none() {
+                dropping_id.set(Some(id));
+                Some(DropGuard { _private: () })
+            } else {
+                None
+            }
+        })
+    }
+
+    /// Checks if the specified id is dropping.
+    pub fn is_dropping(id: usize) -> bool {
+        DROPPING_ID.with(|dropping_id| match dropping_id.get() {
+            Some(dropping_id) => dropping_id.get() == id,
+            None => false,
+        })
+    }
+}
+
+impl Drop for DropGuard {
+    fn drop(&mut self) {
+        DROPPING_ID.with(|dropping_id| {
+            // Should be true as the only way to construct a DropGuard is through DropGuard::take
+            debug_assert!(dropping_id.get().is_some());
+
+            dropping_id.set(None);
+        })
+    }
+}
+
+/// A guard to take while garbage collecting.
+pub(crate) struct GcGuard {
+    _private: (),
+}
+
+impl GcGuard {
+    /// Tries to take the guard. Returns None if the guard is already taken.
+    pub fn take() -> Option<GcGuard> {
+        IN_GC.with(|in_gc| {
+            if in_gc.get() {
+                None
+            } else {
+                in_gc.set(true);
+                Some(GcGuard { _private: () })
+            }
+        })
+    }
+
+    /// A flag to indicate whether a garbage collection is going on. It is undefined behaviour to
+    /// create a new `GcInner` during this time.
+    pub fn is_taken() -> bool {
+        IN_GC.with(|in_gc| in_gc.get())
+    }
+}
+
+impl Drop for GcGuard {
+    fn drop(&mut self) {
+        IN_GC.with(|in_gc| {
+            // Should be true as the only way to construct a GcGuard is through GcGuard::take
+            debug_assert!(in_gc.get());
+            in_gc.set(false);
+        });
+    }
+}

--- a/crates/gc/src/inner.rs
+++ b/crates/gc/src/inner.rs
@@ -1,0 +1,445 @@
+use std::cell::{Cell, RefCell};
+use std::mem;
+use std::ptr::NonNull;
+use std::thread_local;
+
+use crate::mark::Mark;
+
+use flags::GcInnerFlags;
+
+#[derive(Debug)]
+struct GlobalGCData {
+    /// The number of bytes of data allocated.
+    ///
+    /// note this does *not* include the 16 bytes of header included in each GcInner
+    bytes_allocated: usize,
+    /// The maximum number of bytes that can be allocated before a garbage collection is triggered.
+    /// In case a garbage collection is performed, but the `bytes_allocated` still exceeds the
+    /// `max_bytes`, the `max_bytes` is doubled (like a `Vec`s capacity).
+    max_bytes: usize,
+    /// The start of a linked list of `GcInner`s.
+    root: Option<NonNull<GcInner<dyn Mark>>>,
+}
+
+thread_local! {
+    static GLOBAL_GC_DATA: RefCell<GlobalGCData> = RefCell::new(GlobalGCData {
+        bytes_allocated: 0,
+        max_bytes: 256,
+        root: None,
+    });
+
+    /// A flag to indicate whether the 'sweep' phase of the mark and sweep algorithm is going on. It
+    /// is undefined behaviour to dereference a pointer to a inner during this time (unless you are
+    /// the sweeper), as an inner may or may not be dropping at that time.
+    static IS_SWEEPING: Cell<bool> = Cell::new(false);
+}
+
+/// A lock to take during sweeping.
+pub(crate) struct SweepGuard {
+    _private: (),
+}
+
+impl SweepGuard {
+    /// Returns a lock which automatically handles changing the state of the IS_SWEEPING global.
+    /// If None is returned, a sweep is going on and the lock cannot be taken.
+    fn take() -> Option<SweepGuard> {
+        IS_SWEEPING.with(|is_sweeping| {
+            if is_sweeping.get() {
+                None
+            } else {
+                is_sweeping.set(true);
+                Some(SweepGuard { _private: () })
+            }
+        })
+    }
+
+    /// A flag to indicate whether the 'sweep' phase of the mark and sweep algorithm is going on. It
+    /// is undefined behaviour to dereference a pointer to a inner during this time (unless you are
+    /// the sweeper), as an inner may or may not be dropping at that time.
+    pub fn is_taken() -> bool {
+        IS_SWEEPING.with(|is_sweeping| is_sweeping.get())
+    }
+}
+
+impl Drop for SweepGuard {
+    fn drop(&mut self) {
+        IS_SWEEPING.with(|is_sweeping| {
+            // Should be true as the only way to construct a SweepGuard is through SweepGuard::take
+            debug_assert_eq!(is_sweeping.get(), true);
+
+            is_sweeping.set(false);
+        })
+    }
+}
+
+// Sanity check to make sure the bottom bit optimization for `Gc<T>` is valid. Alignment should be
+// unaffected and remain 8 for 64 bit and 4 for 32bit.
+#[repr(align(2))]
+pub(crate) struct GcInner<T: ?Sized + 'static> {
+    /// The reference count and marked and updated flag.
+    flags: GcInnerFlags,
+    /// The next in the linked list of `GcInner`s.
+    next: Option<NonNull<GcInner<dyn Mark>>>,
+    /// The actual value of the object.
+    value: T,
+}
+
+/// Get the first power of 2 greater than a number n
+///
+/// note: if n is isize::MAX or greater, it will overflow and return 0
+fn pow2_greater(mut n: usize) -> usize {
+    n |= n >> 1;
+    n |= n >> 2;
+    n |= n >> 4;
+    n |= n >> 8;
+    n |= n >> 16;
+
+    if mem::size_of::<usize>() == 8 {
+        n |= n >> 32;
+    }
+
+    n + 1
+}
+
+#[cold]
+/// Mark a branch as unlikely to happen to help the compiler with optimization
+fn cold() {}
+
+impl<T: Mark> GcInner<T> {
+    /// Creates a new `GcInner`. Calling this function may trigger a garbage collection.
+    pub fn new(value: T) -> NonNull<Self> {
+        if mem::size_of::<T>() > isize::MAX as usize {
+            panic!("Types must be smaller than isize::MAX");
+        }
+
+        assert!(
+            !SweepGuard::is_taken(),
+            "cannot create Gc object during a garbage collection"
+        );
+
+        GLOBAL_GC_DATA.with(|gcd| {
+            let mut gcd = gcd.borrow_mut();
+
+            // We do not need to check all of these arithmetic operations, because they can't
+            // overflow bytes_allocated and size_of(T) are limited to isize::MAX, so adding the two
+            // will definitely be less than usize::MAX.
+            gcd.bytes_allocated += mem::size_of::<T>();
+            if gcd.bytes_allocated > gcd.max_bytes {
+                collect_garbage(&mut *gcd);
+
+                // collect_garbage also resets max_bytes, so we do not need to check if
+                // bytes_allocated is still greater than max_bytes
+
+                if gcd.bytes_allocated > isize::MAX as usize {
+                    // Almost never going to happen, since the program will probably be
+                    // terminated before taking so much memory
+                    cold();
+                    panic!("allocated more than isize::MAX bytes of data.");
+                }
+            }
+
+            let next = gcd.root.take();
+
+            // SAFETY: `Box::new()` will not give a null pointer
+            let this = unsafe {
+                NonNull::new_unchecked(Box::leak(Box::new(Self {
+                    flags: GcInnerFlags::new(),
+                    next,
+                    value,
+                })))
+            };
+
+            gcd.root = Some(this);
+
+            this
+        })
+    }
+}
+
+impl<T: ?Sized> GcInner<T> {
+    #[inline]
+    pub fn dec_ref(&self) {
+        self.flags.dec_ref();
+    }
+
+    #[inline]
+    pub fn inc_ref(&self) {
+        self.flags.inc_ref();
+    }
+
+    #[inline]
+    pub fn value(&self) -> &T {
+        &self.value
+    }
+}
+
+unsafe impl<T: Mark + ?Sized> Mark for GcInner<T> {
+    fn mark(&self) {
+        // update_reachable should have marked this as updated
+        debug_assert!(self.flags.updated());
+
+        // This is called by other values that implement Mark during a garbage collection, if we
+        // have already visited this node, we need not go through its children again.
+        if !self.flags.marked() {
+            self.flags.set_marked(true);
+            self.value.mark();
+        }
+    }
+
+    fn update_reachable(&self) {
+        // This is called by other values that implement Mark during a garbage collection, if we
+        // have already visited this node, we need not go through its children again.
+        if !self.flags.updated() {
+            self.flags.set_updated(true);
+            self.value.update_reachable();
+        }
+    }
+}
+
+mod flags {
+    use std::cell::Cell;
+    use std::fmt;
+    use std::mem;
+
+    const USIZE_BIT_WIDTH: usize = mem::size_of::<usize>() * 8;
+
+    const MARKED_BIT_OFFSET: usize = USIZE_BIT_WIDTH - 1;
+    const MARKED_FLAG_MASK: usize = 1 << MARKED_BIT_OFFSET;
+
+    const UPDATED_BIT_OFFSET: usize = MARKED_BIT_OFFSET - 1;
+    const UPDATED_FLAG_MASK: usize = 1 << UPDATED_BIT_OFFSET;
+
+    const REF_COUNT_MASK: usize = !(MARKED_FLAG_MASK | UPDATED_FLAG_MASK);
+
+    /// A reference counter and two bools within the size of usize.
+    ///
+    /// The reference counter must not exceed `2^62 - 1` on 64 bit platforms, and `2^30 - 1` on
+    /// 32 bit platforms. Exceeding it will cause a panic.
+    pub(super) struct GcInnerFlags {
+        flags: Cell<usize>,
+    }
+
+    impl GcInnerFlags {
+        /// Creates a `GcInnerFlags` which both bools are false, and has a reference count of 1.
+        pub fn new() -> Self {
+            Self {
+                flags: Cell::new(1),
+            }
+        }
+
+        /// Get the marked flag
+        pub fn marked(&self) -> bool {
+            (self.flags.get() & MARKED_FLAG_MASK) != 0
+        }
+
+        /// Set the marked flag
+        pub fn set_marked(&self, marked: bool) {
+            self.flags
+                .set(self.ref_count() | ((marked as usize) << MARKED_BIT_OFFSET));
+        }
+
+        /// Get the updated flag
+        pub fn updated(&self) -> bool {
+            (self.flags.get() & UPDATED_FLAG_MASK) != 0
+        }
+
+        /// Set the updated flag
+        pub fn set_updated(&self, updated: bool) {
+            self.flags
+                .set(self.ref_count() | ((updated as usize) << UPDATED_BIT_OFFSET));
+        }
+
+        /// Get the reference count
+        pub fn ref_count(&self) -> usize {
+            self.flags.get() & REF_COUNT_MASK
+        }
+
+        /// Increment the reference count by 1.
+        ///
+        /// # Panics
+        ///
+        /// If the adding one to the reference count makes it exceed the max ref count, it will
+        /// panic.
+        pub fn inc_ref(&self) {
+            if self.ref_count() == REF_COUNT_MASK {
+                panic!(
+                    "GcInnerFlags: unexpected inc_ref at max ref_count {}",
+                    REF_COUNT_MASK,
+                );
+            }
+            self.flags.set(self.flags.get() + 1);
+        }
+
+        /// Decrement the reference count by 1.
+        ///
+        /// # Panics
+        ///
+        /// If the reference count is currently 0, it will panic.
+        pub fn dec_ref(&self) {
+            if self.ref_count() == 0 {
+                panic!("GcInnerFlags: unexpected dec_ref at ref_count 0");
+            }
+
+            self.flags.set(self.flags.get() - 1);
+        }
+    }
+
+    impl fmt::Debug for GcInnerFlags {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            f.debug_struct("GcInnerFlags")
+                .field("marked", &self.marked())
+                .field("updated", &self.updated())
+                .field("ref_count", &self.ref_count())
+                .finish()
+        }
+    }
+
+    impl fmt::Binary for GcInnerFlags {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            if f.alternate() {
+                write!(f, "{:#0w$b}", self.flags.get(), w = USIZE_BIT_WIDTH)
+            } else {
+                write!(
+                    f,
+                    "{} {} {:0w$b}",
+                    self.marked() as u8,
+                    self.updated() as u8,
+                    self.ref_count(),
+                    w = UPDATED_BIT_OFFSET
+                )
+            }
+        }
+    }
+}
+
+// The reason for a separate function for the implementation of garbage collection, is so that other
+// functions which have already mutably borrowed it can collect garbage without having to drop the
+// borrow.
+fn collect_garbage(gcd: &mut GlobalGCData) {
+    // # Different types of references to a GcInner
+    // The `Gc` can be of 2 types: reachable and unreachable. The kind is indicated in the lowermost
+    // bit of the pointer (see `Gc` in `src/lib.rs`). An unreachable Gc is one that is not nested
+    // within another Gc object, hence it is unreachable during a mark.
+    //
+    // Every `Gc` starts out as a unreachable, but during a garbage collection if an unreachable Gc
+    // is encountered, it is converted to a reachable one, and the appropriate ref count is
+    // decremented.
+    //
+    // # ref count
+    // Each `GcInner` keeps a reference count of the number of unreachable `Gc`s that exist.
+    //
+    // # garbage collection
+    // The garbage collection can be broken down into 3 phases:
+    // - Update reachable
+    // - Mark
+    // - Sweep
+
+    // UPDATE REACHABLE
+    //
+    // First we go through every node and mark all `Gc`s which are unreachable as reachable and
+    // change the ref count appropriately.
+    {
+        let mut head = gcd.root;
+        while let Some(node) = head {
+            // SAFETY: All `GcInner`s are valid until they are removed in the sweep phase
+            let node = unsafe { node.as_ref() };
+            node.update_reachable();
+            head = node.next;
+        }
+    }
+
+    // MARK
+    //
+    // Then we pass pass over all the `GcInner`s marking them suitably. All objects not marked are
+    // not being referenced from anywhere else can be deleted.
+    {
+        let mut head = gcd.root;
+        while let Some(node) = head {
+            // SAFETY: All `GcInner`s are valid until they are removed in the sweep phase
+            let node = unsafe { node.as_ref() };
+            // If ref_count == 0, then this is a candidate for collecting and unless accessible from
+            // another node will not be marked.
+            if node.flags.ref_count() > 0 {
+                node.mark();
+            }
+            head = node.next;
+        }
+    }
+
+    // SWEEP
+    //
+    // After the mark, there is a sweep which deallocates the unmarked `GcInner`s.
+    {
+        // Should be impossible to fail since sweep is not recursive, and during sweeping, new
+        // objects shouldn't be created
+        SweepGuard::take().expect("unexpected call to sweep, while already sweeping");
+
+        let mut head = gcd.root;
+        // We need to keep track of previous so that we can set its `next` field while removing a
+        // node.
+        let mut prev = None;
+
+        while let Some(node_ptr) = head {
+            // SAFETY: The GcInner list will always have valid inners, since the only time a GcInner
+            // is deallocated, is during the sweep, where it also is removed from the list.
+            let node = unsafe { node_ptr.as_ref() };
+
+            head = if node.flags.marked() {
+                node.flags.set_marked(false);
+                node.flags.set_updated(false);
+                prev = head;
+                node.next
+            } else {
+                // Node not marked, it can be collected
+
+                // Final sanity check to make sure that we aren't deallocating something in use.
+                debug_assert_eq!(node.flags.ref_count(), 0);
+
+                // remove node from the GcInner list.
+                if let Some(mut prev) = prev {
+                    unsafe { prev.as_mut().next = node.next };
+                } else {
+                    gcd.root = node.next;
+                }
+
+                let next = node.next;
+                gcd.bytes_allocated -= mem::size_of_val(&node.value);
+
+                // Drop early to make sure it is never used past this point as the contents it
+                // points to will be dropped at the end of the scope.
+                #[allow(clippy::drop_ref)]
+                drop(node);
+
+                // SAFETY: node was not marked so should be deallocated, all the remaining `Gc`s
+                // are not unreachable, so the `Drop` shouldn't access the inner value to decrement
+                // the reference count.
+                unsafe {
+                    Box::from_raw(node_ptr.as_ptr());
+                }
+
+                next
+            };
+        }
+    }
+
+    // resize max_bytes so that if lots of memory is cleared, the next garbage collection will
+    // happen early instead of waiting for a long time.
+    //
+    // (side effect: collect_garbage is called if bytes_allocated exceeds max_bytes, which means
+    // that if not enough memory could be allocated, this will take care of that too)
+    gcd.max_bytes = pow2_greater(gcd.bytes_allocated);
+    // overflow of pow2_greater is irrelevant since the only time bytes_allocated can be greater
+    // than isize::MAX is if the garbage collection was triggered by an allocation of a new garbage
+    // collected object, which panics if the bytes_allocated is more than isize::MAX.
+}
+
+/// Tries to perform a garbage collection. It returns whether a garbage collection took place.
+pub fn collect() -> bool {
+    GLOBAL_GC_DATA
+        .with(|gcd| {
+            let mut gcd = gcd.try_borrow_mut().ok()?;
+            collect_garbage(&mut *gcd);
+            Some(())
+        })
+        .is_some()
+}

--- a/crates/gc/src/inner.rs
+++ b/crates/gc/src/inner.rs
@@ -350,7 +350,7 @@ fn collect_garbage(gcd: &mut GlobalGCData) {
 
     // MARK
     //
-    // Then we pass pass over all the `GcInner`s marking them suitably. All objects not marked are
+    // Then we pass over all the `GcInner`s marking them suitably. All objects not marked are
     // not being referenced from anywhere else can be deleted.
     {
         let mut head = gcd.root;

--- a/crates/gc/src/inner.rs
+++ b/crates/gc/src/inner.rs
@@ -454,7 +454,7 @@ fn collect_garbage(gcd: &mut GlobalGCData) {
     {
         // Should be impossible to fail since sweep is not recursive, and during sweeping, new
         // objects shouldn't be created
-        SweepGuard::take().expect("unexpected call to sweep, while already sweeping");
+        let _guard = SweepGuard::take().expect("unexpected call to sweep, while already sweeping");
 
         let mut head = gcd.root;
         // We need to keep track of previous so that we can set its `next` field while removing a

--- a/crates/gc/src/inner.rs
+++ b/crates/gc/src/inner.rs
@@ -509,7 +509,9 @@ fn collect_garbage(gcd: &mut GlobalGCData) {
     //
     // (side effect: collect_garbage is called if bytes_allocated exceeds max_bytes, which means
     // that if not enough memory could be allocated, this will take care of that too)
-    gcd.max_bytes = gcd.bytes_allocated.next_power_of_two();
+    gcd.max_bytes = (gcd.bytes_allocated | 128).next_power_of_two();
+    //              ^^^^^^^^^^^^^^^^^^^^^^^^^^^-- makes sure that max_bytes is a minimum of 256
+
     // overflow of pow2_greater is irrelevant since the only time bytes_allocated can be greater
     // than isize::MAX is if the garbage collection was triggered by an allocation of a new garbage
     // collected object, which panics if the bytes_allocated is more than isize::MAX.

--- a/crates/gc/src/lib.rs
+++ b/crates/gc/src/lib.rs
@@ -1,0 +1,248 @@
+//! `Gc<T>` is a thread-local garbage collected object. It provides similar functionality to `Rc<T>`,
+//! but allows for cyclic references.
+//!
+//! `Gc<T>` provides only immutable references to the inner type, and so if a mutable reference is
+//! required, use an interior mutable type within the Gc.
+//!
+//! The garbage collector is a simple mark and sweep collector, which periodically collects
+//! unreferenced objects. However, there is a `collect` function exposed in case a manual collection
+//! trigger is required.
+//!
+//! To see more information about how the mark and sweep algorithm is implemented, see `src/inner.rs`.
+
+use std::marker::PhantomData;
+use std::ops::Deref;
+use std::ptr::NonNull;
+
+mod inner;
+mod mark;
+
+pub use inner::collect;
+pub use mark::Mark;
+
+use inner::{GcInner, SweepGuard};
+use inner_ptr::GcInnerPtr;
+
+/// A garbage collected pointer. Like an `Rc`, it is not thread safe and cloning it does not clone
+/// the inner data. The max number of unreachable clones is `2^62 - 1` for 64 bit systems and
+/// `2^30 - 1` for 32 bit systems, quarter that of `Rc`. An unreachable clone is one that is not
+/// nested in another Gc object.
+///
+/// Also like `Rc`, the inherent methods are all associated functions and should be called with
+/// `Gc::func(&gc_object, ...)` instead of `gc_object.func(...)`. This avoids conflict with the
+/// inner type.
+///
+/// See crate level documentation to learn more about the garbage collection.
+pub struct Gc<T: ?Sized + 'static> {
+    /// The pointer to the inner. It also stores the unreachable flag in the bottom bit.
+    inner: GcInnerPtr<GcInner<T>>,
+    // not safe to send across threads since GlobalGCData is stored as a thread local
+    _marker: PhantomData<std::rc::Rc<T>>,
+}
+
+impl<T: Mark> Gc<T> {
+    /// Create a new Gc<T>.
+    ///
+    /// This will move the value to the heap, and _may trigger a garbage collection_.
+    pub fn new(value: T) -> Self {
+        Self::from_ptr(GcInner::new(value))
+    }
+}
+
+impl<T: ?Sized> Gc<T> {
+    fn from_ptr(ptr: NonNull<GcInner<T>>) -> Self {
+        Self {
+            // SAFETY: GcInner has an alignment of 8 for 64bit, and 4 for 32bit
+            inner: unsafe { GcInnerPtr::new(ptr, true) },
+            _marker: PhantomData,
+        }
+    }
+
+    fn inner(&self) -> &GcInner<T> {
+        assert!(
+            !SweepGuard::is_taken(),
+            "tried to access inner value while freeing Gc objects"
+        );
+
+        // SAFETY: inner will be valid as long as `Gc`s point to it, and since self is a `Gc`, inner
+        // is valid
+        unsafe { &*self.inner.ptr().as_ptr() }
+    }
+
+    #[inline]
+    fn unreachable(&self) -> bool {
+        self.inner.unreachable()
+    }
+
+    /// A unique `usize` corresponding to the object.
+    #[inline]
+    pub fn id(this: &Self) -> usize {
+        this.inner.ptr().as_ptr() as *const u8 as usize
+    }
+
+    /// Returns `true` if both `Gc`s point to the same allocation.
+    #[inline]
+    pub fn ptr_eq(this: &Self, other: &Self) -> bool {
+        this.inner.ptr() == other.inner.ptr()
+    }
+}
+
+impl<T: ?Sized> Clone for Gc<T> {
+    fn clone(&self) -> Self {
+        self.inner().inc_ref();
+
+        Self::from_ptr(self.inner.ptr())
+    }
+}
+
+impl<T: ?Sized> Drop for Gc<T> {
+    fn drop(&mut self) {
+        if self.unreachable() {
+            self.inner().dec_ref();
+        }
+        // NOTE: Do not access inner if self is reachable, as it will panic. This means we are in
+        // the middle of a garbage collection and could possibly be dropping inner.
+    }
+}
+
+unsafe impl<T: Mark + ?Sized> Mark for Gc<T> {
+    fn mark(&self) {
+        // update_reachable should have marked this as reachable
+        debug_assert!(!self.unreachable());
+
+        self.inner().mark();
+    }
+
+    fn update_reachable(&self) {
+        // If unreachable, set reachable and decrement inner ref.
+        if self.unreachable() {
+            self.inner.set_unreachable(false);
+            self.inner().dec_ref();
+        }
+
+        self.inner().update_reachable();
+    }
+}
+
+impl<T> Deref for Gc<T> {
+    type Target = T;
+
+    fn deref(&self) -> &T {
+        self.inner().value()
+    }
+}
+
+/// Kept in a separate module so that no code can accidentally dereference a non-aligned pointer.
+mod inner_ptr {
+    use std::cell::Cell;
+    use std::fmt;
+    use std::ptr::NonNull;
+
+    const UNREACHABLE_BIT_INDEX: usize = 0;
+    const UNREACHABLE_BIT_MASK: usize = 1 << UNREACHABLE_BIT_INDEX;
+
+    /// A wrapper around a pointer which hides the 'unreachable' flag inside a pointer. The value
+    /// must have an alignment >= 2, which means the lowest bit will always be zero.
+    pub(super) struct GcInnerPtr<T: ?Sized> {
+        ptr: Cell<NonNull<T>>,
+    }
+
+    impl<T: ?Sized> GcInnerPtr<T> {
+        /// Create a new GcInnerPtr.
+        ///
+        /// # Safety
+        ///
+        /// * T must have an alignment >= 2
+        pub unsafe fn new(ptr: NonNull<T>, unreachable: bool) -> Self {
+            let mask = (unreachable as usize) << UNREACHABLE_BIT_INDEX;
+            Self {
+                ptr: Cell::new(set_bits(ptr, mask)),
+            }
+        }
+
+        /// Gets the pointer. This pointer is the same as the ptr passed into new.
+        pub fn ptr(&self) -> NonNull<T> {
+            // SAFETY: GcInnerPtr can only be constructed with `GcInnerPtr::new`, which guarantees
+            // alignment must >= 2
+            unsafe { clear_bits(self.ptr.get(), UNREACHABLE_BIT_MASK) }
+        }
+
+        /// Gets the unreachable flag.
+        pub fn unreachable(&self) -> bool {
+            get_bit(self.ptr.get(), UNREACHABLE_BIT_INDEX)
+        }
+
+        /// Sets the unreachable flag.
+        pub fn set_unreachable(&self, unreachable: bool) {
+            // SAFETY: GcInnerPtr can only be constructed with `GcInnerPtr::new`, which guarantees
+            // alignment must be >= 2
+            let ptr = unsafe {
+                let ptr = clear_bits(self.ptr.get(), UNREACHABLE_BIT_MASK);
+                set_bits(ptr, (unreachable as usize) << UNREACHABLE_BIT_INDEX)
+            };
+
+            self.ptr.set(ptr)
+        }
+    }
+
+    impl<T: ?Sized> fmt::Debug for GcInnerPtr<T> {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            f.debug_struct("GcInnerPtr")
+                .field("ptr", &self.ptr())
+                .field("unreachable", &self.unreachable())
+                .finish()
+        }
+    }
+
+    impl<T: ?Sized> fmt::Pointer for GcInnerPtr<T> {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            if f.alternate() {
+                write!(f, "{:#p}", self.ptr())
+            } else {
+                write!(f, "{:p}", self.ptr())
+            }
+        }
+    }
+
+    /// Set the bits on a pointer. The bit mask should be 1 for every bit you want to set, 0 for
+    /// those you don't want to alter.
+    ///
+    /// # Safety
+    ///
+    /// * Be careful what bits you set, as the previous data in them will be lost.
+    ///
+    /// The pointer returned **may not be aligned**. As such care must be taken to call clear the
+    /// extra bits set before dereferencing the pointer.
+    unsafe fn set_bits<T: ?Sized>(ptr: NonNull<T>, bit_mask: usize) -> NonNull<T> {
+        let mut ptr = ptr.as_ptr();
+
+        *(&mut ptr as *mut _ as *mut usize) |= bit_mask;
+
+        NonNull::new_unchecked(ptr)
+    }
+
+    /// Clear the bits on a pointer. The bit mask should be 1 for every bit you want to clear, 0 for
+    /// those you don't want to alter.
+    ///
+    /// # Safety
+    ///
+    /// * Be careful what bits you clear, as the data in them will be lost.
+    /// * Do not clear the bits in such a way that they are all 0, this will cause a NonNull to
+    ///   contain 0 and is UB.
+    ///
+    /// The pointer returned **may not be aligned**. As such care must be taken to call clear the
+    /// extra bits set before dereferencing the pointer.
+    unsafe fn clear_bits<T: ?Sized>(ptr: NonNull<T>, bit_mask: usize) -> NonNull<T> {
+        let mut ptr = ptr.as_ptr();
+
+        // Invert bit_mask so that the bits to clear are 0.
+        *(&mut ptr as *mut _ as *mut usize) &= !bit_mask;
+
+        NonNull::new_unchecked(ptr)
+    }
+
+    /// Get the value at a particular bit on a pointer.
+    fn get_bit<T: ?Sized>(ptr: NonNull<T>, bit_index: usize) -> bool {
+        ptr.as_ptr() as *mut u8 as usize & (1 << bit_index) != 0
+    }
+}

--- a/crates/gc/src/lib.rs
+++ b/crates/gc/src/lib.rs
@@ -16,6 +16,7 @@ use std::marker::PhantomData;
 use std::ops::Deref;
 use std::ptr::NonNull;
 
+mod flag_usize;
 mod guards;
 mod inner;
 mod mark;
@@ -28,9 +29,8 @@ use inner::GcInner;
 use inner_ptr::GcInnerPtr;
 
 /// A garbage collected pointer. Like an `Rc`, it is not thread safe and cloning it does not clone
-/// the inner data. The max number of unreachable clones is `2^62 - 1` for 64 bit systems and `2^30
-/// - 1` for 32 bit systems, quarter that of `Rc`. An unreachable clone is one that is not nested in
-/// another Gc object. The max number of clones (both reachable and unreachable) is the same as `Rc`.
+/// the inner data. The max number of clones is `2^63 - 1` for 64 bit systems and `2^31 - 1` for 32
+/// bit systems, half that of `Rc`.
 ///
 /// Also like `Rc`, the inherent methods are all associated functions and should be called with
 /// `Gc::func(&gc_object, ...)` instead of `gc_object.func(...)`. This avoids conflict with the

--- a/crates/gc/src/lib.rs
+++ b/crates/gc/src/lib.rs
@@ -153,14 +153,14 @@ impl<T: ?Sized> Drop for Gc<T> {
 }
 
 unsafe impl<T: Mark + ?Sized> Mark for Gc<T> {
-    fn mark(&self) {
+    unsafe fn mark(&self) {
         // update_reachable should have marked this as reachable
         debug_assert!(!self.unreachable());
 
         self.inner().mark();
     }
 
-    fn update_reachable(&self) {
+    unsafe fn update_reachable(&self) {
         // If unreachable, set reachable and decrement inner ref.
         if self.unreachable() {
             self.inner.set_unreachable(false);

--- a/crates/gc/src/mark.rs
+++ b/crates/gc/src/mark.rs
@@ -85,6 +85,11 @@ impl_mark!(HashMap<K: Mark, V: Mark, S>; this =>
 impl_mark!(RefCell<T: Mark>; this =>
     mark(&*this.borrow())
 );
+impl_mark!(Option<T: Mark>; this =>
+    if let Some(val) = this {
+        mark(val)
+    }
+);
 
 impl_mark!(String);
 

--- a/crates/gc/src/mark.rs
+++ b/crates/gc/src/mark.rs
@@ -1,0 +1,89 @@
+use std::cell::RefCell;
+use std::collections::HashMap;
+
+macro_rules! impl_mark {
+    ($type:ty) => {
+        unsafe impl Mark for $type {
+            fn mark(&self) {}
+            fn update_reachable(&self) {}
+        }
+    };
+
+    ($ty:ident < $( $N:ident $(: $b0:ident $(+$b:ident)* )? ),* >; $this:ident => $body:expr) => {
+        unsafe impl< $( $N $(: $b0 $(+$b)* )? ),* >
+            $crate::Mark
+            for $ty< $( $N ),* >
+        {
+            fn mark(&self) {
+                fn mark<T: Mark>(t: &T) {
+                    Mark::mark(t)
+                }
+                let $this = self;
+                $body
+            }
+
+            fn update_reachable(&self) {
+                fn mark<T: Mark>(t: &T) {
+                    Mark::update_reachable(t)
+                }
+                let $this = self;
+                $body
+            }
+        }
+    };
+
+    ($ty:ident; $this:ident => $body:expr) => {
+        impl_mark!($ty<>; $this => $body);
+    };
+}
+
+/// This trait must be implemented by types that need to be used inside a `Gc`.
+///
+/// # Safety
+///
+/// Incorrectly implementing the trait is extremely unsafe and can lead to many memory issues.
+///
+/// While implementing this trait, keep the following things in mind:
+///
+/// TODO: Drop unsafety may not be a thing because Gc panics if trying to get value during a drop.
+/// - The types [`Drop`] implementation **should not** access any data within a `Gc`. During garbage
+///   collection, when a Gc object is being dropped, accessing data through cyclic references may
+///   end up trying to read/write from deallocated memory.
+/// - No new `Gc`s should be created inside the `mark`, `update_reachable` and drop functions.
+/// - Read each functions documentation to see what invariants that particular function holds.
+pub unsafe trait Mark {
+    /// This should call `Mark::mark` all contained `Gc`s.
+    ///
+    /// # Safety
+    ///
+    /// If all contained `Gc`s are not marked, then a `Gc` which is still in use could be registered
+    /// to be collected which cause use after free issues.
+    fn mark(&self);
+
+    /// This should call `Mark::update_reachable` on all contained `Gc`s.
+    ///
+    /// # Safety
+    ///
+    /// If all contained `Gc`s are not marked, then there may be an issue with the detecting of an
+    /// object being ready to be collected, which will lead to memory leaks.
+    fn update_reachable(&self);
+}
+
+impl_mark!(Vec<T: Mark>; this =>
+    for item in this {
+        mark(item);
+    }
+);
+
+impl_mark!(HashMap<K: Mark, V: Mark, S>; this =>
+    for (k, v) in this {
+        mark(k);
+        mark(v);
+    }
+);
+
+impl_mark!(RefCell<T: Mark>; this =>
+    mark(&*this.borrow())
+);
+
+impl_mark!(String);

--- a/crates/gc/src/mark.rs
+++ b/crates/gc/src/mark.rs
@@ -45,14 +45,13 @@ macro_rules! impl_mark {
 ///
 /// While implementing this trait, keep the following things in mind:
 ///
-/// TODO: Drop unsafety may not be a thing because Gc panics if trying to get value during a drop.
-/// - The types [`Drop`] implementation **should not** access any data within a `Gc`. During garbage
-///   collection, when a Gc object is being dropped, accessing data through cyclic references may
-///   end up trying to read/write from deallocated memory.
-/// - No new `Gc`s should be created inside the `mark`, `update_reachable` and drop functions.
+/// - The types [`Drop`] implementation **should not** access any data within a `Gc`. If a `Gc` tries
+///   to access the inner value while it is being dropped, it will panic.
+/// - No new `Gc`s should be created inside the `mark`, `update_reachable` and drop functions, as
+///   this may lead to incorrect reference counting.
 /// - Read each functions documentation to see what invariants that particular function holds.
 pub unsafe trait Mark {
-    /// This should call `Mark::mark` all contained `Gc`s.
+    /// This should call `Mark::mark` on all contained `Gc`s.
     ///
     /// # Safety
     ///

--- a/crates/gc/src/mark.rs
+++ b/crates/gc/src/mark.rs
@@ -87,3 +87,16 @@ impl_mark!(RefCell<T: Mark>; this =>
 );
 
 impl_mark!(String);
+
+impl_mark!(i8);
+impl_mark!(i16);
+impl_mark!(i32);
+impl_mark!(i64);
+impl_mark!(i128);
+impl_mark!(isize);
+impl_mark!(u8);
+impl_mark!(u16);
+impl_mark!(u32);
+impl_mark!(u64);
+impl_mark!(u128);
+impl_mark!(usize);

--- a/crates/gc/tests/track_gc.rs
+++ b/crates/gc/tests/track_gc.rs
@@ -1,0 +1,212 @@
+use gc::{collect, Gc, Mark};
+use std::cell::{Cell, RefCell};
+use std::thread::LocalKey;
+use std::thread_local;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct GcTrackerData {
+    updates: usize,
+    marks: usize,
+    drops: usize,
+}
+
+const fn new_td(updates: usize, marks: usize, drops: usize) -> GcTrackerData {
+    GcTrackerData {
+        updates,
+        marks,
+        drops,
+    }
+}
+
+const fn new_tdc(updates: usize, marks: usize, drops: usize) -> Cell<GcTrackerData> {
+    Cell::new(new_td(updates, marks, drops))
+}
+
+struct GcTracker(&'static LocalKey<Cell<GcTrackerData>>);
+
+unsafe impl Mark for GcTracker {
+    fn mark(&self) {
+        self.0.with(|td| {
+            let mut d = td.get();
+            d.marks += 1;
+            td.set(d);
+        })
+    }
+    fn update_reachable(&self) {
+        self.0.with(|td| {
+            let mut d = td.get();
+            d.updates += 1;
+            td.set(d);
+        });
+    }
+}
+
+impl Drop for GcTracker {
+    fn drop(&mut self) {
+        self.0.with(|td| {
+            let mut d = td.get();
+            d.drops += 1;
+            td.set(d);
+        });
+    }
+}
+
+struct GcTrackerCycle {
+    tracker: GcTracker,
+    next: RefCell<Option<Gc<GcTrackerCycle>>>,
+}
+
+unsafe impl Mark for GcTrackerCycle {
+    fn mark(&self) {
+        self.tracker.mark();
+        if let Some(ref next) = *self.next.borrow() {
+            next.mark();
+        }
+    }
+    fn update_reachable(&self) {
+        self.tracker.update_reachable();
+        if let Some(ref next) = *self.next.borrow() {
+            next.update_reachable();
+        }
+    }
+}
+
+struct GcTrackerT<T> {
+    tracker: GcTracker,
+    _data: T,
+}
+
+unsafe impl<T> Mark for GcTrackerT<T> {
+    fn mark(&self) {
+        self.tracker.mark();
+    }
+    fn update_reachable(&self) {
+        self.tracker.update_reachable();
+    }
+}
+
+fn assert_td_state(
+    td: &'static LocalKey<Cell<GcTrackerData>>,
+    updates: usize,
+    marks: usize,
+    drops: usize,
+) {
+    td.with(|td| {
+        assert_eq!(td.get(), new_td(updates, marks, drops));
+    });
+}
+
+#[test]
+fn simple_tracker() {
+    thread_local! {
+        static TD: Cell<GcTrackerData> = new_tdc(0, 0, 0);
+    };
+
+    {
+        let _gc_obj = Gc::new(GcTracker(&TD));
+        assert_td_state(&TD, 0, 0, 0);
+        collect();
+        assert_td_state(&TD, 1, 1, 0);
+    }
+    assert_td_state(&TD, 1, 1, 0);
+    collect();
+
+    // mark is still 1 since ref_count becomes 0 when _gc_obj drops.
+    assert_td_state(&TD, 2, 1, 1);
+}
+
+#[test]
+fn cyclic_tracker() {
+    thread_local! {
+        static TD1: Cell<GcTrackerData> = new_tdc(0, 0, 0);
+        static TD2: Cell<GcTrackerData> = new_tdc(0, 0, 0);
+    };
+
+    {
+        let gc_1 = Gc::new(GcTrackerCycle {
+            tracker: GcTracker(&TD1),
+            next: RefCell::new(None),
+        });
+        let gc_2 = Gc::new(GcTrackerCycle {
+            tracker: GcTracker(&TD2),
+            next: RefCell::new(Some(Gc::clone(&gc_1))),
+        });
+
+        assert_td_state(&TD1, 0, 0, 0);
+        assert_td_state(&TD2, 0, 0, 0);
+
+        collect();
+
+        assert_td_state(&TD1, 1, 1, 0);
+        assert_td_state(&TD2, 1, 1, 0);
+
+        {
+            *gc_1.next.borrow_mut() = Some(gc_2);
+
+            collect();
+        }
+
+        assert_td_state(&TD1, 2, 2, 0);
+        assert_td_state(&TD2, 2, 2, 0);
+
+        collect();
+    }
+
+    assert_td_state(&TD1, 3, 3, 0);
+    assert_td_state(&TD2, 3, 3, 0);
+
+    collect();
+
+    // These would be ready to collected, so they wouldn't be marked.
+    assert_td_state(&TD1, 4, 3, 1);
+    assert_td_state(&TD2, 4, 3, 1);
+}
+
+#[test]
+fn automatically_collects() {
+    thread_local! {
+        static TD1: Cell<GcTrackerData> = new_tdc(0, 0, 0);
+        static TD2: Cell<GcTrackerData> = new_tdc(0, 0, 0);
+    };
+
+    {
+        let _gc_obj_1 = Gc::new(GcTrackerT {
+            tracker: GcTracker(&TD1),
+            _data: [0u8; 200],
+        });
+
+        assert_td_state(&TD1, 0, 0, 0);
+        assert_td_state(&TD2, 0, 0, 0);
+
+        let _gc_obj_2 = Gc::new(GcTrackerT {
+            tracker: GcTracker(&TD2),
+            _data: [0u8; 200],
+        });
+    }
+
+    assert_td_state(&TD1, 1, 1, 0);
+    assert_td_state(&TD2, 0, 0, 0);
+
+    {
+        let _gc_obj_2 = Gc::new(GcTrackerT {
+            tracker: GcTracker(&TD2),
+            _data: [0u8; 100],
+        });
+
+        assert_td_state(&TD1, 2, 1, 1);
+        assert_td_state(&TD2, 1, 0, 1);
+
+        let _gc_obj_1 = Gc::new(GcTrackerT {
+            tracker: GcTracker(&TD1),
+            _data: [0u8; 100],
+        });
+    }
+
+    assert_td_state(&TD1, 2, 1, 1);
+    assert_td_state(&TD2, 1, 0, 1);
+
+    collect();
+
+    assert_td_state(&TD1, 3, 1, 2);
+    assert_td_state(&TD2, 2, 0, 2);
+}

--- a/crates/gc/tests/track_gc.rs
+++ b/crates/gc/tests/track_gc.rs
@@ -25,14 +25,15 @@ const fn new_tdc(updates: usize, marks: usize, drops: usize) -> Cell<GcTrackerDa
 struct GcTracker(&'static LocalKey<Cell<GcTrackerData>>);
 
 unsafe impl Mark for GcTracker {
-    fn mark(&self) {
+    unsafe fn mark(&self) {
         self.0.with(|td| {
             let mut d = td.get();
             d.marks += 1;
             td.set(d);
         })
     }
-    fn update_reachable(&self) {
+
+    unsafe fn update_reachable(&self) {
         self.0.with(|td| {
             let mut d = td.get();
             d.updates += 1;
@@ -57,13 +58,14 @@ struct GcTrackerCycle {
 }
 
 unsafe impl Mark for GcTrackerCycle {
-    fn mark(&self) {
+    unsafe fn mark(&self) {
         self.tracker.mark();
         if let Some(ref next) = *self.next.borrow() {
             next.mark();
         }
     }
-    fn update_reachable(&self) {
+
+    unsafe fn update_reachable(&self) {
         self.tracker.update_reachable();
         if let Some(ref next) = *self.next.borrow() {
             next.update_reachable();
@@ -77,10 +79,11 @@ struct GcTrackerT<T> {
 }
 
 unsafe impl<T> Mark for GcTrackerT<T> {
-    fn mark(&self) {
+    unsafe fn mark(&self) {
         self.tracker.mark();
     }
-    fn update_reachable(&self) {
+
+    unsafe fn update_reachable(&self) {
         self.tracker.update_reachable();
     }
 }

--- a/crates/gc/tests/try_unwrap_gc.rs
+++ b/crates/gc/tests/try_unwrap_gc.rs
@@ -1,0 +1,16 @@
+use gc::Gc;
+
+#[test]
+fn test_try_unwrap() {
+    let mut gc = Gc::new(0);
+
+    {
+        let gc2 = Gc::new(Gc::clone(&gc));
+
+        gc = Gc::try_unwrap(gc).unwrap_err();
+
+        assert_eq!(Gc::try_unwrap(gc2), Ok(Gc::clone(&gc)));
+    }
+
+    assert_eq!(Gc::try_unwrap(gc), Ok(0));
+}

--- a/crates/intermediaries/Cargo.toml
+++ b/crates/intermediaries/Cargo.toml
@@ -8,3 +8,4 @@ edition = "2018"
 crossterm = "0.18.2"
 source = { path = "../source" }
 vm = { path = "../vm" }
+gc = { path = "../gc" }

--- a/crates/intermediaries/src/syntax_node/literal_node.rs
+++ b/crates/intermediaries/src/syntax_node/literal_node.rs
@@ -1,7 +1,6 @@
 use crossterm::style;
 use source::{SourceText, TextSpan};
 use std::cell::RefCell;
-use std::rc::Rc;
 use vm::value::Value;
 
 type Result<T> = std::result::Result<T, ()>;
@@ -62,7 +61,7 @@ impl Parse for String {
             string.push(chr);
         }
 
-        Ok(Value::String(Rc::new(RefCell::new(string))))
+        Ok(Value::String(gc::Gc::new(RefCell::new(string))))
     }
 }
 

--- a/crates/lowerer/Cargo.toml
+++ b/crates/lowerer/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2018"
 vm = { path = "../vm" }
 intermediaries = { path = "../intermediaries" }
 diagnostics = { path = "../diagnostics" }
+gc = { path = "../gc" }
 
 [dev-dependencies]
 source = { path = "../source" }

--- a/crates/lowerer/src/const_evaluator.rs
+++ b/crates/lowerer/src/const_evaluator.rs
@@ -136,7 +136,7 @@ impl<'diagnostics, 'src> ConstEvaluator<'diagnostics, 'src> {
                     k_span,
                 );
             } else {
-                map.insert(k.to_ref_str().to_owned(), v);
+                map.insert(k.into_string(), v);
             }
         }
 

--- a/crates/lowerer/src/const_evaluator.rs
+++ b/crates/lowerer/src/const_evaluator.rs
@@ -115,7 +115,7 @@ impl<'diagnostics, 'src> ConstEvaluator<'diagnostics, 'src> {
         for e in node.elements {
             list.push(self.evaluate_node(e));
         }
-        Value::List(std::rc::Rc::new(std::cell::RefCell::new(list)))
+        Value::List(gc::Gc::new(std::cell::RefCell::new(list)))
     }
 
     fn evaluate_object(&self, mut node: node::ObjectNode) -> Value {
@@ -136,11 +136,11 @@ impl<'diagnostics, 'src> ConstEvaluator<'diagnostics, 'src> {
                     k_span,
                 );
             } else {
-                map.insert(k.into_str(), v);
+                map.insert(k.to_ref_str().to_owned(), v);
             }
         }
 
-        Value::Object(std::rc::Rc::new(std::cell::RefCell::new(map)))
+        Value::Object(gc::Gc::new(std::cell::RefCell::new(map)))
     }
 
     fn evaluate_unary(&self, node: node::UnaryNode) -> Value {

--- a/crates/lowerer/src/lib.rs
+++ b/crates/lowerer/src/lib.rs
@@ -1,4 +1,5 @@
 use diagnostics::Diagnostics;
+use gc::Gc;
 use intermediaries::{node, SyntaxNode, TokenKind};
 use std::cell::RefCell;
 use std::mem;
@@ -318,14 +319,14 @@ impl<'diagnostics, 'src> Lowerer<'diagnostics, 'src> {
                 // Got a function, if first arg is 'self', we want to include it in the object
                 if let Some("self") = node.args.first().map(Rc::as_ref) {
                     object_elements.push(SyntaxNode::LiteralNode(node::LiteralNode::from_val(
-                        Value::String(Rc::new(RefCell::new(k.clone()))),
+                        Value::String(Gc::new(RefCell::new(k.clone()))),
                         v.span().clone(),
                     )));
                     object_elements.push(v.clone());
                 }
             } else {
                 object_elements.push(SyntaxNode::LiteralNode(node::LiteralNode::from_val(
-                    Value::String(Rc::new(RefCell::new(k.clone()))),
+                    Value::String(Gc::new(RefCell::new(k.clone()))),
                     v.span().clone(),
                 )));
                 object_elements.push(v.clone());

--- a/crates/parser/Cargo.toml
+++ b/crates/parser/Cargo.toml
@@ -8,4 +8,5 @@ edition = "2018"
 diagnostics = { path = "../diagnostics" }
 source = { path = "../source" }
 vm = { path = "../vm" }
+gc = { path = "../gc" }
 intermediaries = { path = "../intermediaries" }

--- a/crates/parser/src/lib.rs
+++ b/crates/parser/src/lib.rs
@@ -103,7 +103,9 @@ impl<'diagnostics, 'src> Parser<'diagnostics, 'src> {
     // ----- Other helper Methods -----
 
     fn literal_from_ident(&self, ident: &Token) -> SyntaxNode {
-        let value = Value::String(Rc::new(RefCell::new(self.src[&ident.text_span].to_owned())));
+        let value = Value::String(gc::Gc::new(RefCell::new(
+            self.src[&ident.text_span].to_owned(),
+        )));
         SyntaxNode::LiteralNode(node::LiteralNode::from_val(value, ident.text_span.clone()))
     }
 

--- a/crates/vm/Cargo.toml
+++ b/crates/vm/Cargo.toml
@@ -7,5 +7,6 @@ edition = "2018"
 [dependencies]
 serialize = { path = "../serialize" }
 source = { path = "../source" }
+gc = { path = "../gc" }
 enumflags2 = "0.6.4"
 crossterm = "0.18.2"

--- a/crates/vm/src/bytecode/print_bytecode.rs
+++ b/crates/vm/src/bytecode/print_bytecode.rs
@@ -151,6 +151,8 @@ const YELLOW: style::Color = style::Color::Rgb {
 };
 
 use crate::types::Type;
+
+// note: direct debug print is alright, since there can never be cyclic references in the bytecode.
 fn print_value(value: &crate::value::Value, stdout: &mut std::io::Stdout) -> Result<()> {
     match value.type_() {
         Type::Int | Type::Bool | Type::Float | Type::Range => queue!(

--- a/crates/vm/src/function/mod.rs
+++ b/crates/vm/src/function/mod.rs
@@ -1,4 +1,5 @@
 use crate::bytecode::Bytecode;
+use crate::value::FmtValue;
 use gc::Mark;
 use std::rc::Rc;
 
@@ -100,7 +101,7 @@ impl fmt::Display for Function {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.fn_type)?;
         if let Some(ref this) = self.this {
-            write!(f, " on {}", this)?;
+            write!(f, " on {}", FmtValue(this))?;
         }
         Ok(())
     }

--- a/crates/vm/src/function/mod.rs
+++ b/crates/vm/src/function/mod.rs
@@ -66,11 +66,20 @@ impl Function {
 }
 
 unsafe impl Mark for Function {
-    fn mark(&self) {
+    unsafe fn mark(&self) {
+        // NOTE: This implementation does not call mark on all contained `Gc` values, and so
+        // violates the safety requirement given for the mark function. The `Gc`s not marked are
+        // within the function body. However, this is safe since those `Gc`s will be considered
+        // unreachable as they are not updated in update_reachable.
         self.this.mark();
     }
 
-    fn update_reachable(&self) {
+    unsafe fn update_reachable(&self) {
+        // NOTE: This implementation does not call update_reachable on all contained `Gc` values,
+        // and so violates the safety requirement given for the update_reachable function. The `Gc`s
+        // not updated are within the function body. However, this is safe since those `Gc`s will be
+        // considered unreachable and will not be cyclic (since cycles can only be created within
+        // the Evaluator), so no memory leaks will occur.
         self.this.update_reachable();
     }
 }

--- a/crates/vm/src/function/mod.rs
+++ b/crates/vm/src/function/mod.rs
@@ -1,4 +1,5 @@
 use crate::bytecode::Bytecode;
+use gc::Mark;
 use std::rc::Rc;
 
 mod anilang_fn;
@@ -61,6 +62,16 @@ impl Function {
     pub fn with_this(mut self, this: Value) -> Self {
         self.this = Some(this);
         self
+    }
+}
+
+unsafe impl Mark for Function {
+    fn mark(&self) {
+        self.this.mark();
+    }
+
+    fn update_reachable(&self) {
+        self.this.update_reachable();
     }
 }
 

--- a/crates/vm/src/function/native_fn.rs
+++ b/crates/vm/src/function/native_fn.rs
@@ -1,8 +1,8 @@
 use crate::types::Type;
 use crate::value::{ErrorKind, Result, Value};
+use gc::Gc;
 use std::cell::RefCell;
 use std::io::{self, prelude::*};
-use std::rc::Rc;
 
 pub type NativeFn = fn(Vec<Value>) -> Result<Value>;
 
@@ -43,7 +43,7 @@ pub fn input(args: Vec<Value>) -> Result<Value> {
     let new_len = s.trim_end_matches(|c| c == '\n' || c == '\r').len();
     s.truncate(new_len);
 
-    Ok(Value::String(Rc::new(RefCell::new(s))))
+    Ok(Value::String(Gc::new(RefCell::new(s))))
 }
 
 pub fn push(mut args: Vec<Value>) -> Result<Value> {

--- a/crates/vm/src/function/native_fn.rs
+++ b/crates/vm/src/function/native_fn.rs
@@ -1,5 +1,5 @@
 use crate::types::Type;
-use crate::value::{ErrorKind, Result, Value};
+use crate::value::{print_value, ErrorKind, FmtValue, Result, Value};
 use gc::Gc;
 use std::cell::RefCell;
 use std::io::{self, prelude::*};
@@ -13,10 +13,10 @@ pub fn print(args: Vec<Value>) -> Result<Value> {
     }
 
     for value in &args[..(args.len() - 1)] {
-        print!("{} ", value)
+        print!("{} ", FmtValue(value));
     }
 
-    println!("{}", args.last().unwrap());
+    print_value(args.last().unwrap(), false);
 
     Ok(Value::Null)
 }
@@ -30,7 +30,7 @@ pub fn input(args: Vec<Value>) -> Result<Value> {
     }
 
     if let Some(arg) = args.last() {
-        print!("{} ", arg);
+        print!("{} ", FmtValue(arg));
     }
 
     io::stdout().flush().unwrap();
@@ -98,7 +98,7 @@ pub fn assert(args: Vec<Value>) -> Result<Value> {
     for arg in args {
         if !bool::from(&arg) {
             return Err(ErrorKind::Other {
-                message: format!("Assertion failed: {} is not truthy", arg),
+                message: format!("Assertion failed: {} is not truthy", FmtValue(&arg)),
             });
         }
     }

--- a/crates/vm/src/lib.rs
+++ b/crates/vm/src/lib.rs
@@ -9,7 +9,7 @@ pub use bytecode::{print_bytecode, Bytecode, Instruction, InstructionKind, Label
 pub use deser_ctx::DeserializationContext;
 pub use scope::Scope;
 pub use types::Type;
-pub use value::Value;
+pub use value::{print_value, FmtValue, Value};
 
 // FIXME maybe not great to have this always there even though its only needed during tests
 pub mod test_helpers;

--- a/crates/vm/src/test_helpers.rs
+++ b/crates/vm/src/test_helpers.rs
@@ -1,6 +1,6 @@
 use crate::value::{Object, Value};
+use gc::Gc;
 use std::cell::RefCell;
-use std::rc::Rc;
 
 pub fn i(i: i64) -> Value {
     Value::Int(i)
@@ -15,11 +15,11 @@ pub fn b(b: bool) -> Value {
 }
 
 pub fn s(s: &str) -> Value {
-    Value::String(Rc::new(RefCell::new(s.to_owned())))
+    Value::String(Gc::new(RefCell::new(s.to_owned())))
 }
 
 pub fn l(l: Vec<Value>) -> Value {
-    Value::List(Rc::new(RefCell::new(l)))
+    Value::List(Gc::new(RefCell::new(l)))
 }
 
 pub fn o(o: Vec<(&str, Value)>) -> Value {
@@ -27,7 +27,7 @@ pub fn o(o: Vec<(&str, Value)>) -> Value {
     for (k, v) in o {
         obj.insert(k.to_owned(), v);
     }
-    Value::Object(Rc::new(RefCell::new(obj)))
+    Value::Object(Gc::new(RefCell::new(obj)))
 }
 
 pub fn r(s: i64, e: i64) -> Value {

--- a/crates/vm/src/types/mod.rs
+++ b/crates/vm/src/types/mod.rs
@@ -138,7 +138,7 @@ impl Value {
             }
             _ => unreachable!(
                 "Unexpected explicit cast from {:?} to {:?}, for possible explicit casts call try_cast() instead",
-                self, to_type
+                self.type_(), to_type
             ),
         }
     }

--- a/crates/vm/src/value/cmp_impl.rs
+++ b/crates/vm/src/value/cmp_impl.rs
@@ -22,26 +22,12 @@ impl PartialEq for Value {
             Value::Float(l) => l == r.into(),
             Value::Bool(l) => l == r.into(),
             Value::Range(s, e) => (s..e) == r.into(),
-            Value::String(ref l_rc) => {
-                // Easy to check if both are references to the same string, otherwise check if the
-                // actual strings are equal
-                Rc::ptr_eq(&l_rc, &r.clone().into_rc_str())
-                    || l_rc.borrow().as_str() == r.to_ref_str().as_str()
-            }
-            Value::List(ref l_rc) => {
-                // Easy to check if both are references to the same list, otherwise check if the
-                // actual elements are equal
-                Rc::ptr_eq(&l_rc, &r.clone().into_rc_list())
-                    || l_rc.borrow()[..] == r.to_ref_list()[..]
-            }
-            Value::Object(ref l_rc) => {
-                // Easy to check if both are references to the same object, otherwise check if the
-                // actual elements are equal
-                Rc::ptr_eq(&l_rc, &r.clone().into_rc_obj()) || l_rc.borrow().eq(&*r.to_ref_obj())
-            }
+            Value::String(ref l_rc) => l_rc == r.to_gc_str(),
+            Value::List(ref l_rc) => l_rc == r.to_gc_list(),
+            Value::Object(ref l_rc) => l_rc == r.to_gc_obj(),
             // Functions are only equal if they are references to the same definition, the actual
             // args and function body are not considered.
-            Value::Function(ref l) => Rc::ptr_eq(l, &r.into_rc_fn()),
+            Value::Function(ref l) => Rc::ptr_eq(l, r.to_rc_fn()),
             Value::Null => true,
         }
     }

--- a/crates/vm/src/value/fmt_impl.rs
+++ b/crates/vm/src/value/fmt_impl.rs
@@ -1,4 +1,89 @@
 use super::Value;
+use crossterm::style::Colorize;
+use gc::Gc;
+use std::cell::RefCell;
+use std::collections::HashSet;
+
+#[derive(Default)]
+struct CyclicDetection {
+    ids: HashSet<usize>,
+    should_check: bool,
+}
+
+thread_local! {
+    static CYCLE_DETECTION: RefCell<CyclicDetection> = RefCell::new(Default::default());
+}
+
+/// Wrapper around &Value to allow printing for cyclic values. std::fmt::{Debug, Display} do not
+/// allow for passing a context while printing the values. This means, if there is a cyclic value,
+/// it will keep following the cycle and printing until it crashes. This simple wrapper, creates a
+/// context which keeps track of values encountered, and prints '[ cyclic ]' the second time it
+/// encounters a value.
+pub struct FmtValue<'a>(pub &'a Value);
+
+impl fmt::Display for FmtValue<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        CYCLE_DETECTION.with(|ids| {
+            let mut ids = ids.borrow_mut();
+            ids.should_check = true;
+            ids.ids.clear();
+        });
+        write!(f, "{}", self.0)?;
+        CYCLE_DETECTION.with(|ids| {
+            ids.borrow_mut().should_check = false;
+        });
+        Ok(())
+    }
+}
+
+impl fmt::Debug for FmtValue<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        CYCLE_DETECTION.with(|ids| {
+            let mut ids = ids.borrow_mut();
+            ids.should_check = true;
+            ids.ids.clear();
+        });
+
+        write!(f, "{}", self.0)?;
+
+        CYCLE_DETECTION.with(|ids| {
+            ids.borrow_mut().should_check = false;
+        });
+        Ok(())
+    }
+}
+
+/// prints a value to stdout. This is equivalent to wrapping a Value in FmtValue and printing that
+/// using `println!()`. See FmtValue for more.
+#[inline]
+pub fn print_value(value: &Value, dbg: bool) {
+    if dbg {
+        println!("{:?}", FmtValue(value));
+    } else {
+        println!("{}", FmtValue(value));
+    }
+}
+
+#[inline]
+fn write_cyclic(f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    write!(f, "{}", "[cyclic]".dark_grey())
+}
+
+fn detected_cycle(id: usize) -> bool {
+    CYCLE_DETECTION.with(|cycle_detection| {
+        let mut cycle_detection = cycle_detection.borrow_mut();
+
+        if cycle_detection.should_check {
+            if cycle_detection.ids.contains(&id) {
+                return true;
+            }
+
+            cycle_detection.ids.insert(id);
+        }
+
+        false
+    })
+}
 
 /// When printing we want to only show the inner value, which is what the user expects
 /// for example for an integer 1, when printing, the user expects for it to be printed as
@@ -9,6 +94,10 @@ impl fmt::Display for Value {
         match self {
             Value::String(ref s) => write!(f, "{}", s.borrow()),
             Value::List(ref l) => {
+                if detected_cycle(Gc::id(l)) {
+                    return write_cyclic(f);
+                }
+
                 let l = l.borrow();
                 // Arbitrary number after which it should be pretty printed in multiple lines
                 if l.len() < 8 {
@@ -18,6 +107,10 @@ impl fmt::Display for Value {
                 }
             }
             Value::Object(ref o) => {
+                if detected_cycle(Gc::id(o)) {
+                    return write_cyclic(f);
+                }
+
                 let o = o.borrow();
                 // Arbitrary number after which it should be pretty printed in multiple lines
                 if o.len() < 3 {
@@ -56,7 +149,32 @@ impl fmt::Debug for Value {
                     write!(f, "'")
                 }
             }
-            Value::List(_) | Value::Object(_) => write!(f, "{}", self),
+            Value::List(ref l) => {
+                if detected_cycle(Gc::id(l)) {
+                    return write_cyclic(f);
+                }
+
+                let l = l.borrow();
+                // Arbitrary number after which it should be pretty printed in multiple lines
+                if l.len() < 8 {
+                    write!(f, "{:?}", l)
+                } else {
+                    write!(f, "{:#?}", l)
+                }
+            }
+            Value::Object(ref o) => {
+                if detected_cycle(Gc::id(o)) {
+                    return write_cyclic(f);
+                }
+
+                let o = o.borrow();
+                // Arbitrary number after which it should be pretty printed in multiple lines
+                if o.len() < 3 {
+                    write!(f, "{:?}", o)
+                } else {
+                    write!(f, "{:#?}", o)
+                }
+            }
             Value::Range(s, e) => write!(f, "{}..{}", s, e),
             Value::Function(ref func) => write!(f, "{}", func),
             Value::Int(i) => write!(f, "{:?}", i),

--- a/crates/vm/src/value/from_impl.rs
+++ b/crates/vm/src/value/from_impl.rs
@@ -10,6 +10,7 @@
 /// }
 /// ```
 use super::{Function, List, Object, Value};
+use gc::Gc;
 use std::cell::{Ref, RefCell};
 use std::rc::Rc;
 
@@ -116,17 +117,11 @@ impl From<&Value> for Range<i64> {
 }
 
 impl Value {
-    pub fn into_rc_str(self) -> Rc<RefCell<String>> {
+    pub fn to_gc_str(&self) -> &Gc<RefCell<String>> {
         match self {
             Value::String(s) => s,
             _ => unreachable!(),
         }
-    }
-
-    pub fn into_str(self) -> String {
-        Rc::try_unwrap(self.into_rc_str())
-            .map(RefCell::into_inner)
-            .unwrap_or_else(|rc| rc.borrow().as_str().to_owned())
     }
 
     pub fn to_ref_str(&self) -> Ref<String> {
@@ -136,7 +131,7 @@ impl Value {
         }
     }
 
-    pub fn into_rc_list(self) -> Rc<RefCell<List>> {
+    pub fn to_gc_list(&self) -> &Gc<RefCell<List>> {
         match self {
             Value::List(l) => l,
             _ => unreachable!(),
@@ -150,6 +145,13 @@ impl Value {
         }
     }
 
+    pub fn to_rc_fn(&self) -> &Rc<Function> {
+        match self {
+            Value::Function(f) => f,
+            _ => unreachable!(),
+        }
+    }
+
     pub fn into_rc_fn(self) -> Rc<Function> {
         match self {
             Value::Function(f) => f,
@@ -157,7 +159,7 @@ impl Value {
         }
     }
 
-    pub fn into_rc_obj(self) -> Rc<RefCell<Object>> {
+    pub fn to_gc_obj(&self) -> &Gc<RefCell<Object>> {
         match self {
             Value::Object(o) => o,
             _ => unreachable!(),
@@ -222,19 +224,14 @@ mod tests {
 
     #[test]
     fn val_to_ref_string() {
-        assert_eq!(s("s").into_rc_str().borrow().as_str(), "s");
+        assert_eq!(s("s").to_gc_str().borrow().as_str(), "s");
         assert_eq!(s("s").to_ref_str().as_str(), "s");
-    }
-
-    #[test]
-    fn val_to_str() {
-        assert_eq!(s("string").into_str().as_str(), "string");
     }
 
     #[test]
     fn val_to_ref_list() {
         assert_eq!(
-            l(vec![i(0), i(1), s("s")]).into_rc_list().borrow()[..],
+            l(vec![i(0), i(1), s("s")]).to_gc_list().borrow()[..],
             [i(0), i(1), s("s")]
         );
         assert_eq!(
@@ -253,7 +250,7 @@ mod tests {
         assert_eq!(*ref_obj.get("b").unwrap(), b(true));
         drop(ref_obj);
 
-        let rc_obj = obj.into_rc_obj();
+        let rc_obj = obj.to_gc_obj();
 
         assert_eq!(*rc_obj.borrow().get("a").unwrap(), i(0));
         assert_eq!(*rc_obj.borrow().get("b").unwrap(), b(true));

--- a/crates/vm/src/value/from_impl.rs
+++ b/crates/vm/src/value/from_impl.rs
@@ -131,6 +131,15 @@ impl Value {
         }
     }
 
+    pub fn into_string(self) -> String {
+        match self {
+            Value::String(s) => Gc::try_unwrap(s)
+                .map(RefCell::into_inner)
+                .unwrap_or_else(|gc| gc.borrow().as_str().to_owned()),
+            _ => unreachable!(),
+        }
+    }
+
     pub fn to_gc_list(&self) -> &Gc<RefCell<List>> {
         match self {
             Value::List(l) => l,
@@ -226,6 +235,11 @@ mod tests {
     fn val_to_ref_string() {
         assert_eq!(s("s").to_gc_str().borrow().as_str(), "s");
         assert_eq!(s("s").to_ref_str().as_str(), "s");
+    }
+
+    #[test]
+    fn val_to_string() {
+        assert_eq!(s("string").into_string().as_str(), "string");
     }
 
     #[test]

--- a/crates/vm/src/value/indexing/access_property.rs
+++ b/crates/vm/src/value/indexing/access_property.rs
@@ -1,58 +1,64 @@
 use crate::function::{native, Function, NativeFn};
 use crate::value::{ErrorKind, Ref, Result, Value};
+use gc::Gc;
 use std::rc::Rc;
+
+#[inline]
+fn err_invalid(val: Value, property: Ref<String>) -> Result<Value> {
+    Err(ErrorKind::InvalidProperty { val, property })
+}
+
+#[inline]
+fn err_readonly(val: Value, property: Ref<String>) -> Result<Value> {
+    Err(ErrorKind::ReadonlyProperty { val, property })
+}
 
 impl Value {
     pub fn get_property(self, p: Ref<String>) -> Result<Value> {
-        let err = |val, property| Err(ErrorKind::InvalidProperty { val, property });
-
         let property = p.borrow();
 
         match &self {
             Value::String(s) => match property.as_str() {
                 "len" => Ok(Value::Int(s.borrow().len() as i64)),
-                _ => err(self, Rc::clone(&p)),
+                _ => err_invalid(self, Gc::clone(&p)),
             },
             Value::List(l) => match property.as_str() {
                 "len" => Ok(Value::Int(l.borrow().len() as i64)),
                 "push" => Ok(make_fn(self, native::push)),
                 "pop" => Ok(make_fn(self, native::pop)),
-                _ => err(self, Rc::clone(&p)),
+                _ => err_invalid(self, Gc::clone(&p)),
             },
             Value::Object(o) => {
                 if let Some(val) = o.borrow().get(property.as_str()) {
                     return Ok(val.clone());
                 }
 
-                err(self, Rc::clone(&p))
+                err_invalid(self, Gc::clone(&p))
             }
             Value::Range(s, e) => match property.as_str() {
                 "start" => Ok(Value::Int(*s)),
                 "end" => Ok(Value::Int(*e)),
-                _ => err(self, Rc::clone(&p)),
+                _ => err_invalid(self, Gc::clone(&p)),
             },
             Value::Function(_) => match property.as_str() {
                 "call" => Ok(self),
-                _ => err(self, Rc::clone(&p)),
+                _ => err_invalid(self, Gc::clone(&p)),
             },
             _ => unreachable!(),
         }
     }
 
     pub fn set_property(self, p: Ref<String>, value: Value) -> Result<Value> {
-        let err_invalid = |val, property| Err(ErrorKind::InvalidProperty { val, property });
-        let err_readonly = |val, property| Err(ErrorKind::ReadonlyProperty { val, property });
-
         let property = p.borrow();
 
         match &self {
             Value::String(_) => match property.as_str() {
-                "len" => err_readonly(self, Rc::clone(&p)),
-                _ => err_invalid(self, Rc::clone(&p)),
+                "len" => err_readonly(self, Gc::clone(&p)),
+                _ => err_invalid(self, Gc::clone(&p)),
             },
             Value::List(_) => match property.as_str() {
-                "len" | "push" | "pop" => err_readonly(self, Rc::clone(&p)),
-                _ => err_invalid(self, Rc::clone(&p)),
+                "len" | "push" | "pop" => err_readonly(self, Gc::clone(&p)),
+                _ => err_invalid(self, Gc::clone(&p)),
             },
             Value::Object(o) => {
                 drop(property);
@@ -60,12 +66,12 @@ impl Value {
                 Ok(value)
             }
             Value::Range(..) => match property.as_str() {
-                "start" | "end" => err_readonly(self, Rc::clone(&p)),
-                _ => err_invalid(self, Rc::clone(&p)),
+                "start" | "end" => err_readonly(self, Gc::clone(&p)),
+                _ => err_invalid(self, Gc::clone(&p)),
             },
             Value::Function(_) => match property.as_str() {
-                "call" => err_readonly(self, Rc::clone(&p)),
-                _ => err_invalid(self, Rc::clone(&p)),
+                "call" => err_readonly(self, Gc::clone(&p)),
+                _ => err_invalid(self, Gc::clone(&p)),
             },
             _ => unreachable!(),
         }
@@ -77,7 +83,10 @@ fn make_fn(this: Value, native_fn: NativeFn) -> Value {
 }
 
 fn copy_str(string: Ref<String>) -> String {
-    Rc::try_unwrap(string)
-        .map(std::cell::RefCell::into_inner)
-        .unwrap_or_else(|string| string.borrow().as_str().to_owned())
+    // TODO: Gc has not try_unwrap, which means this optimization can't happen
+    //
+    // Gc::try_unwrap(string)
+    //     .map(std::cell::RefCell::into_inner)
+    //     .unwrap_or_else(|string| string.borrow().as_str().to_owned())
+    String::from(&**string.borrow())
 }

--- a/crates/vm/src/value/indexing/access_property.rs
+++ b/crates/vm/src/value/indexing/access_property.rs
@@ -83,10 +83,7 @@ fn make_fn(this: Value, native_fn: NativeFn) -> Value {
 }
 
 fn copy_str(string: Ref<String>) -> String {
-    // TODO: Gc has not try_unwrap, which means this optimization can't happen
-    //
-    // Gc::try_unwrap(string)
-    //     .map(std::cell::RefCell::into_inner)
-    //     .unwrap_or_else(|string| string.borrow().as_str().to_owned())
-    String::from(&**string.borrow())
+    Gc::try_unwrap(string)
+        .map(std::cell::RefCell::into_inner)
+        .unwrap_or_else(|string| string.borrow().as_str().to_owned())
 }

--- a/crates/vm/src/value/indexing/mod.rs
+++ b/crates/vm/src/value/indexing/mod.rs
@@ -51,7 +51,9 @@ fn normalise_index_len(index: i64, len: i64) -> Result<usize> {
 
 /// impl for index operations
 impl Value {
-    /// Property access is equivalent to indexing by strings
+    /// returns whether self's type is indexable be index_type
+    ///
+    /// note: property access is equivalent to indexing by strings
     pub fn indexable(&self, index_type: Type) -> bool {
         match self.type_() {
             Type::String if (Type::Int | Type::Range | Type::String).contains(index_type) => true,

--- a/crates/vm/src/value/indexing/mod.rs
+++ b/crates/vm/src/value/indexing/mod.rs
@@ -1,7 +1,7 @@
 use super::{ErrorKind, Result, Value};
 use crate::types::Type;
+use gc::Gc;
 use std::cell::RefCell;
-use std::rc::Rc;
 
 mod access_property;
 
@@ -98,7 +98,7 @@ impl Value {
                     _ => unreachable!("Unindexable type should be caught by earlier check"),
                 };
 
-                Ok(Value::String(Rc::new(RefCell::new(s))))
+                Ok(Value::String(Gc::new(RefCell::new(s))))
             }
             Value::List(l) => {
                 let l = l.borrow();
@@ -112,7 +112,7 @@ impl Value {
                         let s = normalise_index(s, l.len() as i64)?;
                         let e = normalise_index_len(e, l.len() as i64)?;
 
-                        Ok(Value::List(Rc::new(RefCell::new(Vec::from(&l[s..e])))))
+                        Ok(Value::List(Gc::new(RefCell::new(Vec::from(&l[s..e])))))
                     }
                     _ => unreachable!("Unindexable type should be caught by earlier check"),
                 }

--- a/crates/vm/src/value/indexing/tests.rs
+++ b/crates/vm/src/value/indexing/tests.rs
@@ -7,7 +7,7 @@ fn err_ior(index: i64, len: i64) -> Result<Value> {
 
 fn test_invalid_prop(v: Value, prop: &str) {
     let p = s(prop);
-    let prop_str = p.clone().into_rc_str();
+    let prop_str = Gc::clone(&p.to_gc_str());
     assert_eq!(
         v.clone().get_at(p),
         Err(ErrorKind::InvalidProperty {
@@ -19,7 +19,7 @@ fn test_invalid_prop(v: Value, prop: &str) {
 
 fn test_invalid_prop_set(v: Value, prop: &str, set: Value) {
     let p = s(prop);
-    let prop_str = p.clone().into_rc_str();
+    let prop_str = Gc::clone(&p.to_gc_str());
     assert_eq!(
         v.clone().set_at(p, set),
         Err(ErrorKind::InvalidProperty {
@@ -31,7 +31,7 @@ fn test_invalid_prop_set(v: Value, prop: &str, set: Value) {
 
 fn test_readonly_prop(v: Value, prop: &str, set: Value) {
     let p = s(prop);
-    let prop_str = p.clone().into_rc_str();
+    let prop_str = Gc::clone(&p.to_gc_str());
     assert_eq!(
         v.clone().set_at(p, set),
         Err(ErrorKind::ReadonlyProperty {

--- a/crates/vm/src/value/mark_impl.rs
+++ b/crates/vm/src/value/mark_impl.rs
@@ -1,0 +1,24 @@
+use super::*;
+use gc::{Gc, Mark};
+
+unsafe impl Mark for Value {
+    fn mark(&self) {
+        match self {
+            Value::String(s) => Gc::mark(s),
+            Value::List(l) => Gc::mark(l),
+            Value::Object(o) => Gc::mark(o),
+            Value::Function(f) => (*f).mark(),
+            _ => {}
+        }
+    }
+
+    fn update_reachable(&self) {
+        match self {
+            Value::String(s) => Gc::update_reachable(s),
+            Value::List(l) => Gc::update_reachable(l),
+            Value::Object(o) => Gc::update_reachable(o),
+            Value::Function(f) => (*f).update_reachable(),
+            _ => {}
+        }
+    }
+}

--- a/crates/vm/src/value/mark_impl.rs
+++ b/crates/vm/src/value/mark_impl.rs
@@ -2,7 +2,7 @@ use super::*;
 use gc::{Gc, Mark};
 
 unsafe impl Mark for Value {
-    fn mark(&self) {
+    unsafe fn mark(&self) {
         match self {
             Value::String(s) => Gc::mark(s),
             Value::List(l) => Gc::mark(l),
@@ -12,7 +12,7 @@ unsafe impl Mark for Value {
         }
     }
 
-    fn update_reachable(&self) {
+    unsafe fn update_reachable(&self) {
         match self {
             Value::String(s) => Gc::update_reachable(s),
             Value::List(l) => Gc::update_reachable(l),

--- a/crates/vm/src/value/mod.rs
+++ b/crates/vm/src/value/mod.rs
@@ -20,6 +20,7 @@ pub type List = Vec<Value>;
 pub type Object = std::collections::HashMap<String, Value>;
 pub type Ref<T> = Gc<RefCell<T>>;
 pub(crate) type Result<T> = std::result::Result<T, ErrorKind>;
+pub use fmt_impl::{print_value, FmtValue};
 
 /// Errors generated during the execution of code are handled through this enum
 #[derive(Debug, PartialEq)]

--- a/crates/vm/src/value/serialize.rs
+++ b/crates/vm/src/value/serialize.rs
@@ -2,6 +2,7 @@ use super::Value;
 use crate::function::Function;
 use crate::types::Type;
 use crate::DeserializationContext;
+use gc::Gc;
 use serialize::{Deserialize, DeserializeCtx, Serialize};
 use std::cell::RefCell;
 use std::io::{self, prelude::*};
@@ -58,11 +59,11 @@ impl DeserializeCtx<DeserializationContext> for Value {
                 let e = i64::deserialize(data)?;
                 Value::Range(s, e)
             }
-            Type::List => Value::List(Rc::new(RefCell::new(Vec::deserialize_with_context(
+            Type::List => Value::List(Gc::new(RefCell::new(Vec::deserialize_with_context(
                 data, ctx,
             )?))),
-            Type::String => Value::String(Rc::new(RefCell::new(String::deserialize(data)?))),
-            Type::Object => Value::Object(Rc::new(RefCell::new(
+            Type::String => Value::String(Gc::new(RefCell::new(String::deserialize(data)?))),
+            Type::Object => Value::Object(Gc::new(RefCell::new(
                 std::collections::HashMap::deserialize_with_context(data, ctx)?,
             ))),
             Type::Function => {


### PR DESCRIPTION
Create a simple garbage collector which allows for cyclic references. It is a simple mark and sweep garbage collector that works as below.

## `Gc` and `GcInner`

Like `Rc`, there is `Gc` which is what is exposed and handled. This contains a pointer to a `GcInner` which stores the actual data and the state of the mark and sweep. The `GcInner` also stores a pointer to the next `GcInner` allowing us to traverse all the heap objects.

## different types of `Gc`

The `Gc` can be of 2 types: reachable and unreachable. The kind is indicated in the lowermost bit of the pointer (see `Gc` in `crates/gc/src/lib.rs`). An unreachable `Gc` is one that is not nested within another `Gc` object, hence it is unreachable during a mark.

Every `Gc` starts out as a unreachable, but during a garbage collection if an unreachable Gc is encountered, it is converted to a reachable one, and the appropriate ref count is decremented.

## ref count
Each `GcInner` keeps a reference count of the number of `Gc`s that exist (similar to Rc::strong_count), and during Update Reachable phase, the number of reachable `Gc`s are counted, and stored in rcnt_marked.

## garbage collection

The garbage collection can be broken down into 3 phases:
- Update reachable - First we go through every node and mark all `Gc`s which are unreachable as reachable and change the ref count appropriately.

- Mark - Then we pass over all the `GcInner`s marking them suitably. All objects not marked are not being referenced from anywhere else can be deleted.

- Sweep - Finally we go through all `GcInner`s and deallocate the unmarked ones.
